### PR TITLE
Updates autocomplete query to new GQL schema

### DIFF
--- a/lib/tags/index.js
+++ b/lib/tags/index.js
@@ -28,8 +28,8 @@ export default class TagContainer extends Component {
       props: { addSingleTag },
       state: { option }
     } = this;
-    if (option.id && option.suggestion) {
-      addSingleTag(option.suggestion, option.id);
+    if (option.tagid && option.label) {
+      addSingleTag(option.label, option.tagid);
       this.refs.autocomplete.setState({ entryValue: '' }); // temp fix to clear the search input
       this.setState({ option: {} }); // clear selected option
     }

--- a/lib/tags/index.js
+++ b/lib/tags/index.js
@@ -63,8 +63,8 @@ export default class TagContainer extends Component {
             ref='autocomplete'
             className='inputBar'
             onKeyUp={this.handleInputChange.bind(this)}
-            filterOption='suggestion'
-            displayOption='suggestion'
+            filterOption='name'
+            displayOption='label'
             onOptionSelected={(option) => this.setState({ option })}
             maxVisible={5}
             customClasses={{

--- a/src/actions/autocomplete.js
+++ b/src/actions/autocomplete.js
@@ -21,8 +21,7 @@ export function getAutocompleteOptions () {
       dispatch(setAutocompleteInSearch());
       const variables = {
         input: searchString,
-        suggester: 'DISPLAYNAME',
-        size: 250
+        size: 100
       };
       graphqlService
         .query(QUERY_AUTOCOMPLETE_INPUT, variables)

--- a/src/constants/queries.js
+++ b/src/constants/queries.js
@@ -1,10 +1,13 @@
 export const QUERY_AUTOCOMPLETE_INPUT = `
-query autocomplete($input: String, $suggestor: SuggesterEnum, $size: Int) {
+query autocomplete($input: String, $size: Int) {
   viewer {
-    autocomplete(text: $input, suggester: $suggestor, size: $size) {
+    autocomplete(text: $input, size: $size) {
       items {
-        suggestion,
-        id
+        name,
+        tagid,
+        label,
+        boost,
+        active
       }
     }
   }

--- a/test/actions/autocomplete.test.js
+++ b/test/actions/autocomplete.test.js
@@ -33,8 +33,11 @@ describe('Autocomplete actions', () => {
         viewer: {
           autocomplete: {
             items: [{
-              id: 'id',
-              suggestion: 'suggestion'
+              'name': 'Spanien',
+              'tagid': 'geo:geonames.2510769',
+              'label': 'Spanien',
+              'boost': 1,
+              'active': true
             }]
           }
         }
@@ -45,8 +48,11 @@ describe('Autocomplete actions', () => {
       {
         type: SET_AUTOCOMPLETE_OPTIONS,
         items: [{
-          id: 'id',
-          suggestion: 'suggestion'
+          'name': 'Spanien',
+          'tagid': 'geo:geonames.2510769',
+          'label': 'Spanien',
+          'boost': 1,
+          'active': true
         }]
       }
     ];
@@ -97,8 +103,11 @@ describe('Autocomplete actions', () => {
   });
   it('setAutocompleteOptions: dispatches an action with items', function (done) {
     const items = [{
-      id: '12345',
-      suggestion: 'Spain'
+      'name': 'Spanien',
+      'tagid': 'geo:geonames.2510769',
+      'label': 'Spanien',
+      'boost': 1,
+      'active': true
     }];
     const expectedAction = {
       type: SET_AUTOCOMPLETE_OPTIONS,

--- a/test/constants/helpers/schema.json
+++ b/test/constants/helpers/schema.json
@@ -88,16 +88,6 @@
                   "defaultValue": null
                 },
                 {
-                  "name": "suggester",
-                  "description": "The suggester you want to use. (ID, DISPLAYNAME)",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "SuggesterEnum",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "size",
                   "description": "Specifies the maximum number of suggestions to include in the response.",
                   "type": {
@@ -156,29 +146,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "SuggesterEnum",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "ID",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DISPLAYNAME",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
           "kind": "SCALAR",
           "name": "Int",
           "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
@@ -233,7 +200,7 @@
           "description": "Suggestion Information",
           "fields": [
             {
-              "name": "suggestion",
+              "name": "tagid",
               "description": null,
               "args": [],
               "type": {
@@ -245,7 +212,43 @@
               "deprecationReason": null
             },
             {
-              "name": "score",
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "label",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "active",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "boost",
               "description": null,
               "args": [],
               "type": {
@@ -257,7 +260,7 @@
               "deprecationReason": null
             },
             {
-              "name": "id",
+              "name": "context",
               "description": null,
               "args": [],
               "type": {
@@ -271,6 +274,16 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -394,16 +407,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "The `Boolean` scalar type represents `true` or `false`.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1950,16 +1953,6 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "suggester",
-                  "description": "The suggester you want to use. (ID, DISPLAYNAME)",
-                  "type": {
-                    "kind": "ENUM",
-                    "name": "SuggesterEnum",
                     "ofType": null
                   },
                   "defaultValue": null


### PR DESCRIPTION
Autocomplete service in GraphQL has been updated to use the new cloudsearch domain - this PR updates the query in the UI 