### PR TITLE
Return primus instance from websocket service initialise method

### DIFF
--- a/src/services/websockets.js
+++ b/src/services/websockets.js
@@ -10,9 +10,9 @@ const socketUrl = 'http://eb-ci.wmm63vqska.eu-west-1.elasticbeanstalk.com';
 * @param {Function} - actionCreatorBinder - function that takes an action
 * and binds it to dispatch
 */
-export const primus = new Primus(socketUrl);
 
 export function initialise (actionCreatorBinder) {
+  const primus = new Primus(socketUrl);
   const {
     saveSearchResult,
     saveSocketConnectionId,
@@ -41,4 +41,5 @@ export function initialise (actionCreatorBinder) {
       saveSocketConnectionId(id);
     });
   });
+  return primus;
 }

--- a/test/services/websockets.test.js
+++ b/test/services/websockets.test.js
@@ -1,4 +1,4 @@
-import { initialise, primus } from '../../src/services/websockets.js';
+import { initialise } from '../../src/services/websockets.js';
 import { expect } from 'chai';
 import thunk from 'redux-thunk';
 import { bindActionCreators } from 'redux';
@@ -13,9 +13,9 @@ describe('Web Socket Service', function () {
   it('initialise - if there is a connection id in the data, calls the saveSocketConnectionId and addSingleTag actions', done => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});
     const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
-    initialise(actionCreatorBinder);
     let counter = 0;
     let expectedActions = [];
+    const primus = initialise(actionCreatorBinder);
     primus.on('data', data => {
       if (data.connection) {
         postDataToClient(data.connection);


### PR DESCRIPTION
Previously all uses of the websocket service used a shared primus instance which meant that the state of the websocket would be in an unpredictable state when running unit tests depending on the ordering of the tests.

Instead create a new primus instance per call to `initialise`, which means that the socket will always be in a fresh known state when running tests against it.