### PR TITLE
Teardown socket instance if router container unmounts

### DIFF
--- a/src/containers/router.js
+++ b/src/containers/router.js
@@ -29,8 +29,12 @@ const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatc
 export default class Root extends Component {
 
   componentWillMount () {
-    websocketService.initialise(actionCreatorBinder);
+    this.socket = websocketService.initialise(actionCreatorBinder);
     fingerprintService.initialise(actionCreatorBinder);
+  }
+
+  componentWilUnmount () {
+    if (this.socket) { this.socket.destroy(); }
   }
 
   render () {


### PR DESCRIPTION
This will prevent any sockets potentially being left open or created if the router component is mounted multiple times.

Fixes #162 