### PR TITLE
Fix formatting of default birthdays

### DIFF
--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -67,14 +67,14 @@ export function combinePassengersForQuery (childAgeArray, numberOfChildren, numb
   const childPassengers = slicedChildAgeArray.map(slicedChildAge => {
     const date = new Date();
     const year = date.getFullYear() - Number(slicedChildAge.split(' ')[0]);
-    const month = ('0' + date.getMonth()).slice(-2);
+    const month = ('0' + (date.getMonth() + 1)).slice(-2);
     const day = ('0' + date.getDate()).slice(-2);
     return ({birthday: `${year}-${month}-${day}`});
   });
   const adultPassengers = _.times(numberOfAdults, function () {
     const date = new Date();
     const year = date.getFullYear() - 20;
-    const month = ('0' + date.getMonth()).slice(-2);
+    const month = ('0' + (date.getMonth() + 1)).slice(-2);
     const day = ('0' + date.getDate()).slice(-2);
     return ({birthday: `${year}-${month}-${day}`}
     );

--- a/test/actions/helpers.test.js
+++ b/test/actions/helpers.test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import { formatTags } from '../../src/actions/helpers.js';
+import { formatTags, combinePassengersForQuery } from '../../src/actions/helpers.js';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('Helpers', () => {
   const tags = [
@@ -9,20 +10,37 @@ describe('Helpers', () => {
     {id: 'amenity:wifi', displayName: 'wifi'},
     {id: 'amenity:pool', displayName: 'pool'}
   ];
-  it('formatQuery: returns an object with geography and amenity keys', (done) => {
-    const res = formatTags(tags);
-    expect(Object.keys(res)).to.deep.equal(['geography', 'amenity']);
-    expect(res.geography).to.deep.equal(['geo:geonames:12345']);
-    expect(res.amenity).to.deep.equal(['amenity:wifi', 'amenity:pool']);
-    done();
+  describe('formatQuery', () => {
+    it('returns an object with geography and amenity keys', (done) => {
+      const res = formatTags(tags);
+      expect(Object.keys(res)).to.deep.equal(['geography', 'amenity']);
+      expect(res.geography).to.deep.equal(['geo:geonames:12345']);
+      expect(res.amenity).to.deep.equal(['amenity:wifi', 'amenity:pool']);
+      done();
+    });
+    it('returns an object with geography key if there are no amenity tags', (done) => {
+      const tags = [
+        {id: 'geo:geonames:12345', displayName: 'spain'}
+      ];
+      const res = formatTags(tags);
+      expect(Object.keys(res)).to.deep.equal(['geography']);
+      expect(res.geography).to.deep.equal(['geo:geonames:12345']);
+      done();
+    });
   });
-  it('formatQuery: returns an object with geography key if there are no amenity tags', (done) => {
-    const tags = [
-      {id: 'geo:geonames:12345', displayName: 'spain'}
-    ];
-    const res = formatTags(tags);
-    expect(Object.keys(res)).to.deep.equal(['geography']);
-    expect(res.geography).to.deep.equal(['geo:geonames:12345']);
-    done();
+  describe('combinePassengersForQuery', () => {
+    before(() => {
+      sinon.useFakeTimers((new Date('2016-05-31')).getTime());
+    });
+    it('sets birthday properties of children according to their age', () => {
+      const result = combinePassengersForQuery(['10', '12'], 2, 2);
+      expect(result[0].birthday).to.eql('2006-05-31');
+      expect(result[1].birthday).to.eql('2004-05-31');
+    });
+    it('sets birthday properties of adults to "today - 20 years"', () => {
+      const result = combinePassengersForQuery(['10', '12'], 2, 2);
+      expect(result[2].birthday).to.eql('1996-05-31');
+      expect(result[3].birthday).to.eql('1996-05-31');
+    });
   });
 });


### PR DESCRIPTION
The value returned by `Date#getMonth` is zero-indexed (see [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth)) so if we use the value to construct a YYYY-MM-DD date string then we need to add one to it to ensure a valid date is produced.

Currently date validation is failing because the dates returned are the 31st April.