### PR TITLE
Refactor websockets tests to not depend on remote service

### DIFF
--- a/test/services/websockets.test.js
+++ b/test/services/websockets.test.js
@@ -6,71 +6,58 @@ import { TAG_ADD_SINGLE_TAG, SAVE_SOCKET_CONNECTION_ID, RECEIVE_SEARCH_RESULT } 
 // mock redux store
 import configureMockStore from '../actions/test-helpers';
 const mockStore = configureMockStore([thunk]);
-const request = require('request');
-const socketUrl = 'http://eb-ci.wmm63vqska.eu-west-1.elasticbeanstalk.com';
 
 describe('Web Socket Service', function () {
-  it('initialise - if there is a connection id in the data, calls the saveSocketConnectionId and addSingleTag actions', done => {
+  it('if there is a connection id in the data, calls the saveSocketConnectionId and addSingleTag actions', done => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});
     const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
-    let counter = 0;
-    let expectedActions = [];
     const primus = initialise(actionCreatorBinder);
     primus.on('data', data => {
-      if (data.connection) {
-        postDataToClient(data.connection);
-        expectedActions = [
-          {
-            type: SAVE_SOCKET_CONNECTION_ID,
-            id: data.connection
+      let expectedActions = [
+        {
+          type: SAVE_SOCKET_CONNECTION_ID,
+          id: data.connection
+        },
+        {
+          type: TAG_ADD_SINGLE_TAG,
+          tag: {
+            displayName: 'Top inspiration',
+            colour: '#8EB8C4',
+            id: 'marketing:homepage.dk.spies'
           },
-          {
-            type: TAG_ADD_SINGLE_TAG,
-            tag: {
-              displayName: 'Top inspiration',
-              colour: '#8EB8C4',
-              id: 'marketing:homepage.dk.spies'
-            },
-            isInitialTag: true
-          }
-        ];
-        expect(store.getActions()).to.deep.equal(expectedActions);
-        done();
-      }
-      ++counter;
-      if (counter === 3) {
-        expectedActions = expectedActions.concat([
-          {
-            type: RECEIVE_SEARCH_RESULT,
-            items: [],
-            initialSearch: false,
-            append: false
-          }
-        ]);
-        expect(store.getActions()).to.deep.equal(expectedActions);
-        done();
+          isInitialTag: true
+        }
+      ];
+      expect(store.getActions()).to.deep.equal(expectedActions);
+      done();
+    });
+    primus.emit('data', {
+      connection: 'abc123'
+    });
+  });
+  it('if there are search results in the data, saves the search results', done => {
+    const store = mockStore({search: { tags: [], resultId: 'abc123' }});
+    const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
+    const primus = initialise(actionCreatorBinder);
+    primus.on('data', data => {
+      let expectedActions = [
+        {
+          type: RECEIVE_SEARCH_RESULT,
+          items: [{ name: 'test' }],
+          initialSearch: false,
+          append: false
+        }
+      ];
+      expect(store.getActions().slice(-1)).to.deep.equal(expectedActions);
+      done();
+    });
+    primus.emit('data', {
+      graphql: {
+        searchId: 'abc123',
+        items: [{
+          name: 'test'
+        }]
       }
     });
   });
 });
-
-function postDataToClient (id) {
-  request({
-    method: 'post',
-    url: socketUrl + '/data',
-    body: {
-      id,
-      searchId: '1234',
-      items: []
-    },
-    json: true
-  }, function (err, res, body) {
-    if (err) return console.error(err);
-    if (body && body.errors) {
-      process.stderr.write(JSON.stringify(body.errors, null, 2));
-      process.exit(1);
-    } else if (body) {
-      process.stdout.write(JSON.stringify(body, null, 2));
-    }
-  });
-}


### PR DESCRIPTION
The previous version of the tests was sending POST requests to a remote service to trigger returning websockets events. This is no longer a supported interface, so stopped working.

Instead we can simplify the triggering of events by calling `emit` directly on the primus instance, which has no dependency on others services being available.