### PR TITLE
Refactor websocket connection events to persist room id

### DIFF
--- a/src/services/websockets.js
+++ b/src/services/websockets.js
@@ -1,7 +1,7 @@
 import * as SearchResultActions from '../actions/search-results.js';
 import * as TagActions from '../actions/tags.js';
 import Primus from '../../src/services/primus.js';
-const socketUrl = 'http://eb-ci.wmm63vqska.eu-west-1.elasticbeanstalk.com';
+const socketUrl = 'http://eb-ci.wmm63vqska.eu-west-1.elasticbeanstalk.com?auto_room=false';
 /**
 * Function that initialises a connection with the web socket server and saves
 * the id to the redux store
@@ -20,26 +20,32 @@ export function initialise (actionCreatorBinder) {
   } = actionCreatorBinder({...SearchResultActions, ...TagActions});
   primus.on('data', function received (data) {
     console.log('incoming socket data', data);
-    if (data.connection) {
-      saveSocketConnectionId(data.connection);
+    if (data.graphql) {
+      saveSearchResult(data);
+    }
+  });
+
+  primus.once('open', (data) => {
+    primus.id((id) => {
+      saveSocketConnectionId(id);
+      join(id);
+      primus.on('reconnected', () => { join(id); });
       // only launch the home page query after the socket connection has been
       // initialised
       addSingleTag('Top inspiration', 'marketing:homepage.dk.spies', true);
-    } else if (data.graphql) {
-      saveSearchResult(data);
-    } else {
-      return;
-    }
+    });
   });
 
   primus.on('error', function error (err) {
     console.error('Something horrible has happened', err.stack);
   });
 
-  primus.on('reconnected', function reconnected (opts) {
-    primus.id(function (id) {
-      saveSocketConnectionId(id);
+  function join (room) {
+    primus.write({
+      action: 'join',
+      room: room
     });
-  });
+  }
+
   return primus;
 }

--- a/test/services/websockets.test.js
+++ b/test/services/websockets.test.js
@@ -1,6 +1,7 @@
 import { initialise } from '../../src/services/websockets.js';
 import { expect } from 'chai';
 import thunk from 'redux-thunk';
+import simple from 'simple-mock';
 import { bindActionCreators } from 'redux';
 import { TAG_ADD_SINGLE_TAG, SAVE_SOCKET_CONNECTION_ID, RECEIVE_SEARCH_RESULT } from '../../src/constants/actionTypes';
 // mock redux store
@@ -8,32 +9,77 @@ import configureMockStore from '../actions/test-helpers';
 const mockStore = configureMockStore([thunk]);
 
 describe('Web Socket Service', function () {
-  it('if there is a connection id in the data, calls the saveSocketConnectionId and addSingleTag actions', done => {
+  it('calls the saveSocketConnectionId and addSingleTag actions when connection is opened', () => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});
     const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
     const primus = initialise(actionCreatorBinder);
-    primus.on('data', data => {
-      let expectedActions = [
-        {
-          type: SAVE_SOCKET_CONNECTION_ID,
-          id: data.connection
+    primus.id = (cb) => { cb('abc123'); };
+    primus.emit('open');
+    let expectedActions = [
+      {
+        type: SAVE_SOCKET_CONNECTION_ID,
+        id: 'abc123'
+      },
+      {
+        type: TAG_ADD_SINGLE_TAG,
+        tag: {
+          displayName: 'Top inspiration',
+          colour: '#8EB8C4',
+          id: 'marketing:homepage.dk.spies'
         },
-        {
-          type: TAG_ADD_SINGLE_TAG,
-          tag: {
-            displayName: 'Top inspiration',
-            colour: '#8EB8C4',
-            id: 'marketing:homepage.dk.spies'
-          },
-          isInitialTag: true
-        }
-      ];
-      expect(store.getActions()).to.deep.equal(expectedActions);
-      done();
-    });
-    primus.emit('data', {
-      connection: 'abc123'
-    });
+        isInitialTag: true
+      }
+    ];
+    expect(store.getActions()).to.deep.equal(expectedActions);
+  });
+  it('only calls the saveSocketConnectionId and addSingleTag actions on first connection', () => {
+    const store = mockStore({search: { tags: [], resultId: '1234' }});
+    const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
+    const primus = initialise(actionCreatorBinder);
+    primus.id = (cb) => { cb('abc123'); };
+    primus.emit('open');
+    primus.emit('open');
+    primus.emit('open');
+    let expectedActions = [
+      {
+        type: SAVE_SOCKET_CONNECTION_ID,
+        id: 'abc123'
+      },
+      {
+        type: TAG_ADD_SINGLE_TAG,
+        tag: {
+          displayName: 'Top inspiration',
+          colour: '#8EB8C4',
+          id: 'marketing:homepage.dk.spies'
+        },
+        isInitialTag: true
+      }
+    ];
+    expect(store.getActions()).to.deep.equal(expectedActions);
+  });
+  it('subscribes to a primus room on connection', () => {
+    const store = mockStore({search: { tags: [], resultId: '1234' }});
+    const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
+    const primus = initialise(actionCreatorBinder);
+    simple.mock(primus, 'write');
+    primus.id = (cb) => { cb('abc123'); };
+    primus.emit('open');
+    expect(primus.write.callCount).to.equal(1);
+    expect(primus.write.lastCall.args[0]).to.deep.equal({ action: 'join', room: 'abc123' });
+  });
+  it('subscribes to the original primus room on reconnection', () => {
+    const store = mockStore({search: { tags: [], resultId: '1234' }});
+    const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
+    const primus = initialise(actionCreatorBinder);
+    simple.mock(primus, 'write');
+    primus.id = (cb) => { cb('abc123'); };
+    primus.emit('open');
+    expect(primus.write.callCount).to.equal(1);
+    expect(primus.write.lastCall.args[0]).to.deep.equal({ action: 'join', room: 'abc123' });
+    primus.id = (cb) => { cb('def456'); };
+    primus.emit('reconnected');
+    expect(primus.write.callCount).to.equal(2);
+    expect(primus.write.lastCall.args[0]).to.deep.equal({ action: 'join', room: 'abc123' });
   });
   it('if there are search results in the data, saves the search results', done => {
     const store = mockStore({search: { tags: [], resultId: 'abc123' }});


### PR DESCRIPTION
When the websocket reconnects following a network loss it was reconnecting to a new room id, which prevents it from being able to receive search results from any in flight searches. Instead save the room id only once, and when the socket reconnects, re-subscribe to the same room id.

Additionally, ensure that the default tags are set only on the first connection and not on any subsequent reconnections.

Fixes #180