### PR TITLE
Scrolling fixes

### DIFF
--- a/lib/scroll-view/index.js
+++ b/lib/scroll-view/index.js
@@ -61,7 +61,6 @@ class ScrollView extends Component {
       // scroll listeners added back on componentDidUpdate
       this._removeScrollListeners();
       this.page += 1;
-      console.log('CALLING LOAD DATA >>>>>>>>>>', this.page);
       loadData(this.page);
     }
   }

--- a/src/actions/search-results.js
+++ b/src/actions/search-results.js
@@ -217,8 +217,8 @@ export function loadMoreItemsIntoFeed (page) {
       dispatch(updateDisplayedItems(items.slice(0, 10)));
     } else if (items.length >= page * 5) {
       dispatch(updateDisplayedItems(items.slice(0, page * 5)));
-    } else if (items.length === 0) {
-      dispatch(updateDisplayedItems([]));
+    } else if (displayedItems.length === 0 && items.length === 0) {
+      return; // no unecessary re-render if no items returned
     }
   };
 }

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -52,7 +52,7 @@ class ISearch extends Component {
       <ScrollView
         loadingThreshold={500}
         loadData={loadMoreItemsIntoFeed}
-        endScroll={this.state.endScroll}
+        endScroll={displayedItems.length === 0}
       >
         <SearchResults
           changeRoute={changeRoute}

--- a/test/actions/search-results.test.js
+++ b/test/actions/search-results.test.js
@@ -194,12 +194,11 @@ describe('Search Results Actions', () => {
       expect(store.getActions()[1]).to.deep.equal(expectedAction2);
       done();
     });
-    it(`loadMoreItemsIntoFeed: if items is empty calls updateDisplayedItems
-      with an empty array'`, done => {
+    it(`loadMoreItemsIntoFeed: if displayedItems and items are both empty
+      arrays then return'`, done => {
       const store = mockStore({search: { displayedItems: [], items: [] }});
-      const expectedActions = [{type: UPDATE_DISPLAYED_ITEMS, items: []}];
-      store.dispatch(actions.loadMoreItemsIntoFeed(2));
-      expect(store.getActions()).to.deep.equal(expectedActions);
+      store.dispatch(actions.loadMoreItemsIntoFeed(1));
+      expect(store.getActions()).to.deep.equal([]);
       done();
     });
   });

--- a/test/components/isearch.test.js
+++ b/test/components/isearch.test.js
@@ -10,7 +10,7 @@ import ISearch from '../../src/components/isearch/';
 
 const defaultProps = {
   tags: [],
-  items: [],
+  displayedItems: [],
   onYesFilter: () => {},
   onFilterClick: () => {},
   showAddMessage: () => {},


### PR DESCRIPTION
Fixes bug where if the user scrolls to the bottom of the page before any tiles have loaded, no tiles will display from #200.

@tomgco I think this should fix the bug you noted. 