### PR TITLE
Remove tiles from `items` as well as `displayedItems`

### DIFF
--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -215,12 +215,15 @@ export default function search (state = initialState, action) {
         items: []
       };
     case TILES_REMOVE_TILE:
-      const filteredItems = state.displayedItems.filter(item => {
+      const iterator = item => {
         return item.id !== action.id;
-      });
+      };
+      const displayed = state.displayedItems.filter(iterator);
+      const backlog = state.items.filter(iterator);
       return {
         ...state,
-        displayedItems: filteredItems
+        displayedItems: displayed,
+        items: backlog
       };
     default:
       return state;

--- a/src/utils/mock-search-results.json
+++ b/src/utils/mock-search-results.json
@@ -197,6 +197,7 @@
     },
     {
       "type": "tile",
+      "id": "amenity:wifi",
       "tile": {
         "prefix": "Do you need access to",
         "displayName": "Wifi",

--- a/test/reducers/search.test.js
+++ b/test/reducers/search.test.js
@@ -26,7 +26,6 @@ import { expect } from 'chai';
 import reducer, { initialState } from '../../src/reducers/search';
 import mockResults from '../../src/utils/mock-search-results.json';
 import { mockTiles } from '../../src/reducers/utils/mockData.js';
-import mockItem from '../../src/utils/mock-item.js';
 
 const mockItems = [mockResults.items[0]]; // an array with one packageOffer
 
@@ -282,14 +281,15 @@ describe('Search Reducer', () => {
     it('TILES_REMOVE_TILE -> removes a tile from the displayed items', (done) => {
       const initialStateWithItems = {
         ...initialState,
-        displayedItems: [mockItem]
+        displayedItems: mockResults.items.slice(0, 1),
+        items: mockResults.items
       };
       const action = {type: TILES_REMOVE_TILE, id: 'e73e4919e237887f70f6024011502243'};
       const state = reducer(initialStateWithItems, action);
-      console.log(state);
       const expectedState = {
         ...initialState,
-        displayedItems: []
+        displayedItems: [],
+        items: mockResults.items.slice(1)
       };
       expect(state).to.deep.equal(expectedState);
       done();


### PR DESCRIPTION
The way our infinite scroll works we maintain two arrays of items, one of the items displayed (a.k.a `displayedItems`) and one of the complete item backlog (`items`).

When removing a tile by clicking the close button it was removing only from the `displayedItems` which meant that when triggering infinite scroll and fetching new items from the backlog then this still included the removed tile, causing it to be restored into the stack.

Fix this by removing the item from both arrays when triggering the `TILES_REMOVE_TILE` action.

Fixes #189 