### PR TITLE
Scroll fixes

### DIFF
--- a/lib/scroll-view/index.js
+++ b/lib/scroll-view/index.js
@@ -29,10 +29,10 @@ class ScrollView extends Component {
   constructor () {
     super();
     this._scrollHandler = this._scrollHandler.bind(this);
-    this.page = 0; // to keep track of the current page to enable pagination. Dont' want to re-render on page change so just set it on `this` instead of a state
   }
 
   componentDidMount () {
+    this.page = this.props.page;
     this._attachScrollListeners();
   }
 
@@ -46,6 +46,11 @@ class ScrollView extends Component {
 
   componentDidUpdate () {
     this._attachScrollListeners();
+  }
+
+  componentWillReceiveProps (nextProps) {
+    console.log('scrollpage', nextProps.page);
+    this.page = nextProps.page;
   }
 
   _scrollHandler () {
@@ -81,14 +86,16 @@ class ScrollView extends Component {
 ScrollView.defaultProps = {
   loadingThreshold: 200,
   endScroll: false,
-  loadData: () => console.log('Pass in a function to load more data given a page number')
+  loadData: () => console.log('Pass in a function to load more data given a page number'),
+  page: 0
 };
 
 ScrollView.propTypes = {
   loadingThreshold: PropTypes.number,
   loadData: PropTypes.func,
   endScroll: PropTypes.bool,
-  children: PropTypes.obj
+  children: PropTypes.obj,
+  page: PropTypes.number // scroll page
 };
 
 export default ScrollView;

--- a/src/actions/search-results.js
+++ b/src/actions/search-results.js
@@ -273,7 +273,7 @@ export function loadMoreItemsIntoFeed (page) {
     if (displayedItems.length < 10 && items.length > 0) {
       return dispatch(updateDisplayedItems(items.slice(0, 10)));
     } else if (items.length >= page * 5) {
-      return dispatch(updateDisplayedItems(items.slice(0, page * 5))); // if 5 x page number exists send back 5x
+      return dispatch(updateDisplayedItems(items.slice(0, page * 5))); // if 5 x page number exists send back 5 x
     } else if (items.length > displayedItems.length) {
       return dispatch(updateDisplayedItems(items)); // if 5 x page number doesn't exist send all available items
     } else if (displayedItems.length === 0 && items.length === 0) {

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -46,13 +46,15 @@ class ISearch extends Component {
       removeTile,
       displayedItems,
       loadMoreItemsIntoFeed,
-      addSingleTag
+      addSingleTag,
+      scrollPage
     } = this.props;
     return (
       <ScrollView
         loadingThreshold={500}
         loadData={loadMoreItemsIntoFeed}
         endScroll={displayedItems.length === 0}
+        page={scrollPage}
       >
         <SearchResults
           changeRoute={changeRoute}
@@ -193,7 +195,11 @@ ISearch.propTypes = {
   onYesFilter: PropTypes.func,
   onFilterClick: PropTypes.func,
   filterVisibleState: PropTypes.object,
+
+  // scroll view
   loadMoreItemsIntoFeed: PropTypes.func,
+  scrollPage: PropTypes.number,
+
   // autocomplete
   autocompleteOptions: PropTypes.array,
   inAutoCompleteSearch: PropTypes.bool,

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -21,6 +21,14 @@ class SearchResults extends Component {
     super();
     this.mapItems = this.mapItems.bind(this);
   }
+
+  shouldComponentUpdate (nextProps) {
+    if (nextProps.items.length === this.props.items.length) {
+      return false;
+    } else {
+      return true;
+    }
+  }
   handleVisibility (isVisible, item) {
     if (dataLayer && isVisible && item.type === 'packageOffer') {
       dataLayer.push({

--- a/src/containers/isearch.js
+++ b/src/containers/isearch.js
@@ -30,7 +30,8 @@ function mapStateToProps (state) {
       autocompleteError,
       autocompleteOptions,
       inAutoCompleteSearch,
-      resultId
+      resultId,
+      scrollPage
     },
     travelInfo: {
       numberOfChildren,
@@ -86,7 +87,8 @@ function mapStateToProps (state) {
     numberOfChildrenTitle,
     durationTitle,
     resultId,
-    viewedArticles
+    viewedArticles,
+    scrollPage
   };
 }
 

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -38,6 +38,7 @@ export const initialState = {
     displayName: 'Top inspiration',
     id: 'marketing:homepage.dk.spies'
   },
+  scrollPage: 0,
   fingerprint: '',
   bucketId: '',
   resultId: '',
@@ -93,7 +94,8 @@ export default function search (state = initialState, action) {
     case UPDATE_DISPLAYED_ITEMS:
       return {
         ...state,
-        displayedItems: action.items
+        displayedItems: action.items,
+        scrollPage: state.scrollPage + 1
       };
     case BUSY_SEARCHING:
       return {

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -38,7 +38,7 @@ export const initialState = {
     displayName: 'Top inspiration',
     id: 'marketing:homepage.dk.spies'
   },
-  scrollPage: 0,
+  scrollPage: 6,
   fingerprint: '',
   bucketId: '',
   resultId: '',

--- a/test/reducers/search.test.js
+++ b/test/reducers/search.test.js
@@ -91,7 +91,8 @@ describe('Search Reducer', () => {
       const state = reducer(undefined, action);
       const expectedState = {
         ...initialState,
-        displayedItems: mockItems
+        displayedItems: mockItems,
+        scrollPage: 1
       };
       expect(state).to.deep.equal(expectedState);
       done();

--- a/test/reducers/search.test.js
+++ b/test/reducers/search.test.js
@@ -92,7 +92,7 @@ describe('Search Reducer', () => {
       const expectedState = {
         ...initialState,
         displayedItems: mockItems,
-        scrollPage: 1
+        scrollPage: 7
       };
       expect(state).to.deep.equal(expectedState);
       done();


### PR DESCRIPTION
Adds prop to specify scroll initial page to scroll view and sets this to 6 (as 30 items loaded initially and 5 per page) so when the user scrolls to the bottom of the first page the page is not reloaded with 5 items. 