### PR TITLE
Refactor out common components from search results to reduce repetition

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -100,7 +100,9 @@ class SearchResults extends Component {
       items.map((item, index) => {
         return (
           <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
-           {this.renderItem(item, index)};
+            <div key={index} className='gridItem'>
+              {this.renderItem(item, index)}
+            </div>
           </VisibilitySensor>
         );
       })
@@ -117,13 +119,19 @@ class SearchResults extends Component {
       addSingleTag
     } = this.props;
 
+    const removeButton = () => {
+      return (
+        <div onClick={() => removeTile(item.id)}>
+          <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
+        </div>
+      );
+    };
+
     if (item.packageOffer) {
       return (
-        <div className='gridItem'>
-          <div onClick={() => removeTile(item.id)}>
-            <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
-          </div>
-          <div key={index} className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
+        <div>
+          {removeButton()}
+          <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
             <PackageTile
               key={item.packageOffer.id}
               packageOffer={item.packageOffer}
@@ -139,10 +147,8 @@ class SearchResults extends Component {
       const contentExists = item.tile.sections && item.tile.sections.length > 0;
       if (item.tile.type === 'article' && contentExists) {
         return (
-          <div key={index} className='gridItem'>
-            <div onClick={() => removeTile(item.id)}>
-              <img className='removeTileButton' src={removeTileButton} alt='cancel' />
-            </div>
+          <div>
+            {removeButton()}
             <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
               <ArticleTile
                 className={viewedArticles.indexOf(item.tile.id) > -1 ? 'visited' : ''}
@@ -154,29 +160,24 @@ class SearchResults extends Component {
         );
       } else if (item.tile.type === 'destination' && contentExists) {
         return (
-          <div key={index} className='gridItem'>
-            <div onClick={() => removeTile(item.id)}>
-              <img className='removeTileButton' src={removeTileButton} alt='cancel' />
-            </div>
+          <div>
+            {removeButton()}
             <div className='clickable'>
               <DestinationTile {...item} />
             </div>
           </div>
         );
-      } else {
-        return <div/>;
       }
     } else if (item.type === 'filter') {
       return (
-        <div key={index} className='gridItem'>
-          <FilterTile
-            onYesFilter={onYesFilter}
-            onNoFilter={() => removeTile(item.id)}
-            description={item.filter}
-          />
-        </div>
+        <FilterTile
+          onYesFilter={onYesFilter}
+          onNoFilter={() => removeTile(item.id)}
+          description={item.filter}
+        />
       );
     }
+    return <div/>;
   }
 
   render () {

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -109,6 +109,17 @@ class SearchResults extends Component {
     );
   }
 
+  removeButton (id) {
+    const {
+      removeTile
+    } = this.props;
+    return (
+      <div onClick={() => removeTile(id)}>
+        <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
+      </div>
+    );
+  }
+
   renderItem (item, index) {
     const {
       onYesFilter,
@@ -119,18 +130,10 @@ class SearchResults extends Component {
       addSingleTag
     } = this.props;
 
-    const removeButton = () => {
-      return (
-        <div onClick={() => removeTile(item.id)}>
-          <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
-        </div>
-      );
-    };
-
     if (item.packageOffer) {
       return (
         <div>
-          {removeButton()}
+          {this.removeButton(item.id)}
           <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
             <PackageTile
               key={item.packageOffer.id}
@@ -148,7 +151,7 @@ class SearchResults extends Component {
       if (item.tile.type === 'article' && contentExists) {
         return (
           <div>
-            {removeButton()}
+            {this.removeButton(item.id)}
             <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
               <ArticleTile
                 className={viewedArticles.indexOf(item.tile.id) > -1 ? 'visited' : ''}
@@ -161,7 +164,7 @@ class SearchResults extends Component {
       } else if (item.tile.type === 'destination' && contentExists) {
         return (
           <div>
-            {removeButton()}
+            {this.removeButton(item.id)}
             <div className='clickable'>
               <DestinationTile {...item} />
             </div>

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -30,7 +30,10 @@ class SearchResults extends Component {
     }
   }
   handleVisibility (isVisible, item) {
-    if (dataLayer && isVisible && item.type === 'packageOffer') {
+    if (!dataLayer || !isVisible) {
+      return;
+    }
+    if (item.type === 'packageOffer') {
       dataLayer.push({
         'ecommerce': {
           'impressions': [{
@@ -41,7 +44,7 @@ class SearchResults extends Component {
         },
         'event': 'impressionsPushed'
       });
-    } else if (dataLayer && isVisible && item.type === 'filter') {
+    } else if (item.type === 'filter') {
       dataLayer.push({
         'ecommerce': {
           'impressions': [{
@@ -52,7 +55,7 @@ class SearchResults extends Component {
         },
         'event': 'impressionsPushed'
       });
-    } else if (dataLayer && isVisible && item.type === 'article') {
+    } else if (item.type === 'article') {
       dataLayer.push({
         'event': 'impressionsPushed',
         'ecommerce': {

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -94,89 +94,89 @@ class SearchResults extends Component {
 
   mapItems () {
     const {
-      items,
+      items
+    } = this.props;
+    return (
+      items.map((item, index) => {
+        return (
+          <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
+           {this.renderItem(item, index)};
+          </VisibilitySensor>
+        );
+      })
+    );
+  }
+
+  renderItem (item, index) {
+    const {
       onYesFilter,
       totalPassengers,
-      // resultId,
       changeRoute,
       viewedArticles,
       removeTile,
       addSingleTag
     } = this.props;
 
-    // TODO replace urls to valid ones
-    return (
-      items.map((item, index) => {
-        if (item.packageOffer) {
-          return (
-            <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
-              <div className='gridItem'>
-                <div onClick={() => removeTile(item.id)}>
-                  <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
-                </div>
-                <div key={index} className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
-                  <PackageTile
-                    key={item.packageOffer.id}
-                    packageOffer={item.packageOffer}
-                    totalPassengers={totalPassengers}
-                    itemId={item.packageOffer.id}
-                    removeTile={removeTile}
-                    item={item}
-                  />
-                </div>
-              </div>
-            </VisibilitySensor>
-          );
-        } else if (item.type === 'tile') {
-          const contentExists = item.tile.sections && item.tile.sections.length > 0;
-          if (item.tile.type === 'article' && contentExists) {
-            return (
-              <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
-                <div key={index} className='gridItem'>
-                  <div onClick={() => removeTile(item.id)}>
-                    <img className='removeTileButton' src={removeTileButton} alt='cancel' />
-                  </div>
-                  <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
-                    <ArticleTile
-                      className={viewedArticles.indexOf(item.tile.id) > -1 ? 'visited' : ''}
-                      {...item}
-                      onAddTagClick={(event) => { event.stopPropagation(); addSingleTag(item.tile.name, item.tile.id); removeTile(item.id); }}
-                    />
-                  </div>
-                </div>
-              </VisibilitySensor>
-            );
-          } else if (item.tile.type === 'destination' && contentExists) {
-            return (
-              <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
-                <div key={index} className='gridItem'>
-                  <div onClick={() => removeTile(item.id)}>
-                    <img className='removeTileButton' src={removeTileButton} alt='cancel' />
-                  </div>
-                  <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/destination/${item.url}`); }}>
-                    <DestinationTile {...item} />
-                  </div>
-                </div>
-              </VisibilitySensor>
-            );
-          } else {
-            return <div/>;
-          }
-        } else if (item.type === 'filter') {
-          return (
-            <VisibilitySensor key={index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
-              <div key={index} className='gridItem'>
-                <FilterTile
-                  onYesFilter={onYesFilter}
-                  onNoFilter={() => removeTile(item.id)}
-                  description={item.filter}
-                />
-              </div>
-            </VisibilitySensor>
-          );
-        }
-      })
-    );
+    if (item.packageOffer) {
+      return (
+        <div className='gridItem'>
+          <div onClick={() => removeTile(item.id)}>
+            <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
+          </div>
+          <div key={index} className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
+            <PackageTile
+              key={item.packageOffer.id}
+              packageOffer={item.packageOffer}
+              totalPassengers={totalPassengers}
+              itemId={item.packageOffer.id}
+              removeTile={removeTile}
+              item={item}
+            />
+          </div>
+        </div>
+      );
+    } else if (item.type === 'tile') {
+      const contentExists = item.tile.sections && item.tile.sections.length > 0;
+      if (item.tile.type === 'article' && contentExists) {
+        return (
+          <div key={index} className='gridItem'>
+            <div onClick={() => removeTile(item.id)}>
+              <img className='removeTileButton' src={removeTileButton} alt='cancel' />
+            </div>
+            <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
+              <ArticleTile
+                className={viewedArticles.indexOf(item.tile.id) > -1 ? 'visited' : ''}
+                {...item}
+                onAddTagClick={(event) => { event.stopPropagation(); addSingleTag(item.tile.name, item.tile.id); removeTile(item.id); }}
+              />
+            </div>
+          </div>
+        );
+      } else if (item.tile.type === 'destination' && contentExists) {
+        return (
+          <div key={index} className='gridItem'>
+            <div onClick={() => removeTile(item.id)}>
+              <img className='removeTileButton' src={removeTileButton} alt='cancel' />
+            </div>
+            <div className='clickable'>
+              <DestinationTile {...item} />
+            </div>
+          </div>
+        );
+      } else {
+        return <div/>;
+      }
+    } else if (item.type === 'filter') {
+      return (
+        <div key={index} className='gridItem'>
+          <FilterTile
+            onYesFilter={onYesFilter}
+            onNoFilter={() => removeTile(item.id)}
+            description={item.filter}
+          />
+        </div>
+      );
+    }
   }
 
   render () {

--- a/src/utils/mock-search-results.json
+++ b/src/utils/mock-search-results.json
@@ -196,6 +196,43 @@
       }
     },
     {
+      "id": "1461583539893",
+      "type": "tile",
+      "ranking": 1,
+      "tile": {
+        "name": "Vandring på Kreta",
+        "id": "tile:article.HyVj2zA",
+        "url": "http://www.spies.dk/sport/vandrerejser-kreta",
+        "type": "destination",
+        "tags": [
+          {
+            "label": "Creta",
+            "value": "hotel:mhid.e5qdaxr"
+          },
+          {
+            "label": "Hiking (dk)",
+            "value": "marketing:NE.hiking"
+          },
+          {
+            "label": "Greece",
+            "value": "geo:geonames.390903"
+          }
+        ],
+        "sections": [
+          {
+            "image": "http://images2.spies.dk/images/SitePageGlobal/training_walking_crete_top.jpg?v=3",
+            "text": "Kretas varierede natur er perfekt til vandreture. Gennem øen løber en bjergkæde med flere høje toppe, som skaber en imponerende kontrast til de mange dalsænkninger og kløfter. En vandretur begynder ofte oppe i højden og slutter ved en dejlig strand, hvor det er muligt at bade og spise frokost med en dejlig udsigt.\n\nKreta er en ø med store højdeforskelle, hvilket yder, at der er mange betagende udsigtspunkter over de ind imellem dramatiske omgivelser. Flere bjergtoppe tårner sig mere end 1500 meter over havet, og enkelte over 2000 meter. Det stiller krav til fysikken, og derfor er det vigtigt, at du vælger en rute, der passer til din form. Øens varme og tørre klima betyder, at selv enkle vandrestier kan blive udfordrende.\n\nGode sko er altid et must, og for mange af ruterne – eksempelvis den, der går gennem Samariakløften – er det tilrådeligt med vandrestøvler. Selv om du er vant til at vandre på egen hånd, anbefaler vi, at du vandrer med en guide. Kontakt din Spies-vært på rejsemålet for mere information.",
+            "title": "Vandring på Kreta"
+          },
+          {
+            "image": "",
+            "text": "* Flotte naturoplevelser.\n* Gode vandrestier af varierende længde og sværhedsgrad.\n* Kuperede og udfordrende ruter for dig, der er vant til at vandre.\n* Erfarne guider med godt lokalkendskab.",
+            "title": "Hvorfor skal du vandre på Kreta?"
+          }
+        ]
+      }
+    },
+    {
       "id": "amenity:wifi",
       "type": "filter",
       "filter": {

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -17,6 +17,7 @@ describe('Component', function () {
     const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
     beforeEach(() => {
       removeStub.reset();
+      global.dataLayer = [];
     });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;
@@ -30,6 +31,21 @@ describe('Component', function () {
     });
     it('should wrap each tile in a VisibilitySensor component', () => {
       expect(wrapper.find(VisibilitySensor).length).to.equal(4);
+    });
+    it('pushes an event to the dataLayer when a tile becomes visible', () => {
+      wrapper.find(VisibilitySensor).first().simulate('change', true);
+      expect(dataLayer.length).to.equal(1);
+      expect(dataLayer[0].event).to.equal('impressionsPushed');
+    });
+    it('sets the impression id to the package reference for package tile impressions', () => {
+      wrapper.find(VisibilitySensor).first().simulate('change', true);
+      expect(dataLayer.length).to.equal(1);
+      expect(dataLayer[0].ecommerce.impressions[0].id).to.equal('A01A37');
+    });
+    it('sets the impression id to the filter id for filter tile impressions', () => {
+      wrapper.find(VisibilitySensor).at(3).simulate('change', true);
+      expect(dataLayer.length).to.equal(1);
+      expect(dataLayer[0].ecommerce.impressions[0].id).to.equal('amenity:wifi');
     });
     it('should render a PackageTile for items with a type of packageOffer', () => {
       expect(wrapper.find(PackageTile)).to.have.length(1);

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -8,26 +8,38 @@ import DestinationTile from '../../lib/destination-tile';
 import FilterTile from '../../lib/filter-tile';
 import VisibilitySensor from 'react-visibility-sensor';
 import mockTiles from '../../src/utils/mock-search-results';
+import sinon from 'sinon';
 
 describe('Component', function () {
   global.dataLayer = [];
   describe('<SearchResults />', function () {
-    const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]}/>);
+    const removeStub = sinon.stub();
+    const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
+    beforeEach(() => {
+      removeStub.reset();
+    });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;
-      expect(children).to.have.length(3);
+      expect(children).to.have.length(4);
       done();
     });
-    it('should render 3 elements with the class .gridItem and none .visited', function (done) {
-      expect(wrapper.find('.gridItem').length).to.equal(3);
+    it('should render 4 elements with the class .gridItem and none .visited', function (done) {
+      expect(wrapper.find('.gridItem').length).to.equal(4);
       expect(wrapper.find('.visited').length).to.equal(0);
       done();
     });
     it('should wrap each tile in a VisibilitySensor component', () => {
-      expect(wrapper.find(VisibilitySensor).length).to.equal(3);
+      expect(wrapper.find(VisibilitySensor).length).to.equal(4);
     });
     it('should render a PackageTile for items with a type of packageOffer', () => {
       expect(wrapper.find(PackageTile)).to.have.length(1);
+    });
+    it('package result tile contains a remove button', () => {
+      const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items.slice(0, 1)} viewedArticles={[]} removeTile={removeStub} />);
+      expect(wrapper.find('.removeTileButton').length).to.equal(1);
+      wrapper.find('.removeTileButton').parent().simulate('click');
+      expect(removeStub.called).to.be.true;
+      expect(removeStub.calledWith('e73e4919e237887f70f6024011502243')).to.be.true;
     });
     it('should render an ArticleTile for tile items with a type of article', () => {
       expect(wrapper.find(ArticleTile)).to.have.length(1);
@@ -39,20 +51,30 @@ describe('Component', function () {
       mockTiles.items[1].tile.sections = sections;
       expect(wrapper.find(ArticleTile)).to.have.length(0);
     });
+    it('article result tile contains a remove button', () => {
+      const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items.slice(1, 2)} viewedArticles={[]} removeTile={removeStub} />);
+      expect(wrapper.find('.removeTileButton').length).to.equal(1);
+      wrapper.find('.removeTileButton').parent().simulate('click');
+      expect(removeStub.called).to.be.true;
+      expect(removeStub.calledWith('1461583539892')).to.be.true;
+    });
     it('should render a DestinationTile for tile items with a type of destination', () => {
-      mockTiles.items[1].tile.type = 'destination';
       const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]}/>);
-      mockTiles.items[1].tile.type = 'article';
       expect(wrapper.find(DestinationTile)).to.have.length(1);
     });
     it('does not render a DestinationTile if the destination item has no sections', () => {
-      const sections = mockTiles.items[1].tile.sections;
-      mockTiles.items[1].tile.type = 'destination';
-      mockTiles.items[1].tile.sections = [];
+      const sections = mockTiles.items[2].tile.sections;
+      mockTiles.items[2].tile.sections = [];
       const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]}/>);
-      mockTiles.items[1].tile.type = 'article';
-      mockTiles.items[1].tile.sections = sections;
+      mockTiles.items[2].tile.sections = sections;
       expect(wrapper.find(DestinationTile)).to.have.length(0);
+    });
+    it('destination result tile contains a remove button', () => {
+      const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items.slice(2, 3)} viewedArticles={[]} removeTile={removeStub} />);
+      expect(wrapper.find('.removeTileButton').length).to.equal(1);
+      wrapper.find('.removeTileButton').parent().simulate('click');
+      expect(removeStub.called).to.be.true;
+      expect(removeStub.calledWith('1461583539893')).to.be.true;
     });
     it('should render a FilterTile for items with a type of filter', () => {
       expect(wrapper.find(FilterTile)).to.have.length(1);

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -6,6 +6,7 @@ import PackageTile from '../../lib/package-tile';
 import ArticleTile from '../../lib/article-tile';
 import DestinationTile from '../../lib/destination-tile';
 import FilterTile from '../../lib/filter-tile';
+import VisibilitySensor from 'react-visibility-sensor';
 import mockTiles from '../../src/utils/mock-search-results';
 
 describe('Component', function () {
@@ -21,6 +22,9 @@ describe('Component', function () {
       expect(wrapper.find('.gridItem').length).to.equal(3);
       expect(wrapper.find('.visited').length).to.equal(0);
       done();
+    });
+    it('should wrap each tile in a VisibilitySensor component', () => {
+      expect(wrapper.find(VisibilitySensor).length).to.equal(3);
     });
     it('should render a PackageTile for items with a type of packageOffer', () => {
       expect(wrapper.find(PackageTile)).to.have.length(1);


### PR DESCRIPTION
In the search results component, when mapping the results to tile components, the wrapping components - i.e. `<VisibilitySensor/>` and `<div className="gridItem"/>` - were being repeated in each clause of the conditional statement on the type of tile being rendered, resulting in the same code existing in 4 places. 

Instead factor out the generating code for the inner component of the tile and then wrap all the results in the common grid item components.

Additionally adds test coverage for the search results component.