### PR TITLE
Impressions

### DIFF
--- a/src/components/search-results/analytics-helper.js
+++ b/src/components/search-results/analytics-helper.js
@@ -1,0 +1,45 @@
+/**
+ *
+ * @type {{package: (function(): {id: string, brand: string, list: string}), filter: (function(): {id: number, brand:
+ *   string, list: string}), tile: (function(): {id: *, category: string, brand: string, list: string})}}
+ * @private
+ */
+const impressionObject = {
+  package: (item) => {
+    return {
+      'id': item.packageOffer.provider.reference,
+      'brand': 'hotel_tile',
+      'list': 'inspirational search feed'
+    };
+  },
+  filter: (item) => {
+    return {
+      'id': item.id,
+      'brand': 'filter_tile',
+      'list': 'inspirational search feed'
+    };
+  },
+  tile: (item) => {
+    return {
+      'id': item.tile.name,
+      'category': 'article category', // can this be fetched?
+      'brand': 'article_tile', // hardcoded
+      'list': 'inspirational search feed'
+    };
+  }
+};
+
+/**
+ * Given an item, returns a data object ready to be pushed to
+ * @param item
+ * @returns {{ecommerce: {impressions: Array}, event: string}}
+ */
+export const impresionDataFactory = (item) => {
+  var analyticsImpression = {
+    'event': 'impressionsPushed',
+    'ecommerce': {
+      'impressions': [ impressionObject[ item.type ](item) ]
+    }
+  };
+  return analyticsImpression;
+};

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -5,6 +5,7 @@ import PackageTile from '../../../lib/package-tile';
 import ArticleTile from '../../../lib/article-tile';
 import VisibilitySensor from 'react-visibility-sensor';
 import DestinationTile from '../../../lib/destination-tile';
+import { impresionDataFactory } from './analytics-helper';
 
 const removeTileButton = require('../../assets/cancel.svg');
 import './style.css';
@@ -21,7 +22,6 @@ class SearchResults extends Component {
     super();
     this.mapItems = this.mapItems.bind(this);
   }
-
   shouldComponentUpdate (nextProps) {
     if (nextProps.items.length === this.props.items.length) {
       return false;
@@ -29,63 +29,32 @@ class SearchResults extends Component {
       return true;
     }
   }
+
   handleVisibility (isVisible, item) {
     if (!dataLayer || !isVisible) {
       return;
     }
-    if (item.type === 'packageOffer') {
-      dataLayer.push({
-        'ecommerce': {
-          'impressions': [{
-            'id': item.packageOffer.provider.reference,
-            'brand': 'hotel_tile',
-            'list': 'inspirational search feed'
-          }]
-        },
-        'event': 'impressionsPushed'
-      });
-    } else if (item.type === 'filter') {
-      dataLayer.push({
-        'ecommerce': {
-          'impressions': [{
-            'id': item.id,
-            'brand': 'filter_tile',
-            'list': 'inspirational search feed'
-          }]
-        },
-        'event': 'impressionsPushed'
-      });
-    } else if (item.type === 'article') {
-      dataLayer.push({
-        'event': 'impressionsPushed',
-        'ecommerce': {
-          'impressions': [{
-            'id': 'article name', // can this be extracted from the backend?
-            'category': 'article category', // can this be fetched?
-            'brand': 'article_tile', // hardcoded
-            'list': 'inspirational search feed'
-          }]
-        }});
-    }
+    dataLayer.push(impresionDataFactory(item));
     return;
   }
+
   handleClickEvent (item) {
     const clickEventObject = {
       'event': 'productClick',
       'ecommerce': {
         'click': {
-          'actionField': {'list': 'inspirational search feed'},
+          'actionField': { 'list': 'inspirational search feed' },
           'products': []
         }
       }
     };
-    if (dataLayer && item.type === 'packageOffer') {
+    if (dataLayer && item.type === 'package') {
       clickEventObject.ecommerce.click.products.push({
         'id': item.packageOffer.provider.reference,
         'brand': 'hotel_tile'
       });
       dataLayer.push(clickEventObject);
-    } else if (dataLayer && item.type === 'article') {
+    } else if (dataLayer && item.type === 'tile') {
       clickEventObject.ecommerce.click.products.push({
         'id': item.tile.id,
         'brand': 'article_tile'
@@ -118,7 +87,7 @@ class SearchResults extends Component {
     } = this.props;
     return (
       <div onClick={() => removeTile(id)}>
-        <img className='removeTileButton' src={removeTileButton} alt='cancelled' />
+        <img className='removeTileButton' src={removeTileButton} alt='cancelled'/>
       </div>
     );
   }
@@ -137,7 +106,8 @@ class SearchResults extends Component {
       return (
         <div>
           {this.removeButton(item.id)}
-          <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
+          <div className='clickable'
+               onClick={() => { this.handleClickEvent(item); changeRoute(`/hotel/${item.url}`); }}>
             <PackageTile
               key={item.packageOffer.id}
               packageOffer={item.packageOffer}
@@ -155,7 +125,8 @@ class SearchResults extends Component {
         return (
           <div>
             {this.removeButton(item.id)}
-            <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
+            <div className='clickable'
+                 onClick={() => { this.handleClickEvent(item); changeRoute(`/article/${item.url}`); }}>
               <ArticleTile
                 className={viewedArticles.indexOf(item.tile.id) > -1 ? 'visited' : ''}
                 {...item}
@@ -168,7 +139,8 @@ class SearchResults extends Component {
         return (
           <div>
             {this.removeButton(item.id)}
-            <div className='clickable' onClick={() => { this.handleClickEvent(item); changeRoute(`/destination/${item.url}`); }}>
+            <div className='clickable'
+                 onClick={() => { this.handleClickEvent(item); changeRoute(`/destination/${item.url}`); }}>
               <DestinationTile {...item} />
             </div>
           </div>
@@ -194,7 +166,7 @@ class SearchResults extends Component {
         disableImagesLoaded={false}
         className='grid load-effect'
       >
-      {this.mapItems()}
+        {this.mapItems()}
       </Masonry>
     );
   }

--- a/src/utils/mock-search-results.json
+++ b/src/utils/mock-search-results.json
@@ -2,7 +2,7 @@
   "items": [
    {
      "id": "e73e4919e237887f70f6024011502243",
-     "type": "packageOffer",
+     "type": "package",
      "ranking": 3,
      "packageOffer": {
        "hotel": {

--- a/test/components/analytics-fixtures.js
+++ b/test/components/analytics-fixtures.js
@@ -1,0 +1,60 @@
+'use strict';
+
+export default {
+  article: {
+    item: {
+      id: 'whatever',
+      type: 'tile',
+      tile: {
+        name: 'articleName'
+      }
+    },
+    expectedResult: {
+      'event': 'impressionsPushed',
+      'ecommerce': {
+        'impressions': [{
+          'id': 'articleName',
+          'category': 'article category',
+          'brand': 'article_tile',
+          'list': 'inspirational search feed'
+        }]
+      }
+    }
+  },
+  package: {
+    item: {
+      type: 'package',
+      packageOffer: {
+        provider: {
+          reference: 'fixtureReference'
+        }
+      }
+    },
+    expectedResult: {
+      'event': 'impressionsPushed',
+      'ecommerce': {
+        'impressions': [{
+          'id': 'fixtureReference',
+          'brand': 'hotel_tile',
+          'list': 'inspirational search feed'
+        }]
+      }
+    }
+  },
+  filter: {
+    item: {
+      type: 'filter',
+      id: 'filterID'
+    },
+    expectedResult: {
+      'event': 'impressionsPushed',
+      'ecommerce': {
+        'impressions': [{
+          'id': 'filterID',
+          'brand': 'filter_tile',
+          'list': 'inspirational search feed'
+        }]
+      }
+    }
+  }
+};

--- a/test/components/analytics-helper.test.js
+++ b/test/components/analytics-helper.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import * as analyticsHelper from '../../src/components/search-results/analytics-helper';
+import fixtures from './analytics-fixtures';
+import { expect } from 'chai';
+
+describe('Analytics helper', function () {
+  describe('Impressions data factory', function () {
+    it('Should create a proper impression element given an article item ', function (done) {
+      let articleItem = fixtures.article.item;
+      let analyticsObject = analyticsHelper.impresionDataFactory(articleItem);
+      let expectedObject = fixtures.article.expectedResult;
+      expect(analyticsObject).to.deep.equal(expectedObject);
+      done();
+    });
+    it('Should create a proper impression element given a package item ', function (done) {
+      let packageItem = fixtures.package.item;
+      let analyticsObject = analyticsHelper.impresionDataFactory(packageItem);
+      let expectedObject = fixtures.package.expectedResult;
+      expect(analyticsObject).to.deep.equal(expectedObject);
+      done();
+    });
+    it('Should create a proper impression element given a filter item ', function (done) {
+      let filterItem = fixtures.filter.item;
+      let analyticsObject = analyticsHelper.impresionDataFactory(filterItem);
+      let expectedObject = fixtures.filter.expectedResult;
+      expect(analyticsObject).to.deep.equal(expectedObject);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Impressions restored. 
Search results items types where changed, so they didn't match anymore with our analytic condition. This is why this functionality was lost. 

Now it's restored again. And I've decouple the analytics code for impressions and added a couple of tests. 


@nelsonic @nikhilaravi @jackcarlisle Question: I've added an analytics `helper`. I really don't know where would be the proper place. I would suggest to create in `lib` a folder for all the analytics related code. But right now our front end is completely (or almost completely) based in components and all `lib` content are components. Would it be ok for you to have at `lib` something that is not a react component? Or any other suggestions?   

