### PR TITLE
Execute search when clicking result in autosuggest dropdown

### DIFF
--- a/lib/search-bar/index.js
+++ b/lib/search-bar/index.js
@@ -13,10 +13,10 @@ export default class SearchBarContainer extends Component {
   }
 
   handleOnOptionSelected (option) {
-    this.setState({ option });
-    setTimeout(function () {
-      document.activeElement.blur();
-    }, 500);
+    this.setState({ option }, () => {
+      this.onSearchButtonClick();
+    });
+    document.activeElement.blur();
   }
 
   onInputFocus (e) {


### PR DESCRIPTION
Automatically executes a search once option state has updated. Uses callback on `setState` because `setState` is potentially async - see https://facebook.github.io/react/docs/component-api.html

Removes the need for a setTimeout call around the blur because we no longer rely on the field being focussed to submit on pressing enter since we explicitly submit anyway.