### PR TITLE
Implementing per environment builds

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,1 +1,16 @@
-export const basename = '/isearch/0.17/index.html';
+const config = {
+  common: {
+    socketUrl: 'https://ci-socket-server.tcdl.io?auto_room=false',
+    graphqlUrl: 'https://f0uih51vu0.execute-api.eu-west-1.amazonaws.com/ci/graphql'
+  },
+  ci: {
+    socketUrl: 'https://ci-socket-server.tcdl.io?auto_room=false',
+    graphqlUrl: 'https://f0uih51vu0.execute-api.eu-west-1.amazonaws.com/ci/graphql'
+  },
+  production: {
+    socketUrl: 'https://ci-socket-server.tcdl.io?auto_room=false',
+    graphqlUrl: 'https://f0uih51vu0.execute-api.eu-west-1.amazonaws.com/prod/graphql'
+  }
+};
+
+export default config;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,46 +4,75 @@ var fs = require('fs');
 var exec = require('child_process').exec;
 var pkg = require('./package.json');
 var mime = require('mime-types');
-
-/*
-* config values
-*
-*/
-
-var version = pkg.version.split('.')[2]; // using the patch version number
-var bucketName = 'www.tcdl.io';
-var bucketfolder = 'isearch/0.' + version + '/';
-var basename = '/isearch/0.' + version + '/index.html';
 /**
  * building the bundle
  */
 
-gulp.task('deploy', function () {
-  exec(`echo "export const basename = '${basename}';" > config.js`, function (error, stdout, stderr) {
-    console.error('error', error);
+gulp.task('ci:deploy', function () {
+  /*
+  * config values
+  *
+  */
+
+  var version = pkg.version.split('.')[2]; // using the patch version number
+  var bucketName = 'www.tcdl.io';
+  var bucketfolder = 'isearch/0.' + version + '/';
+
+  return exec('npm run ci:build', function (error, stdout, stderr) {
     if (error === null) {
-      return exec('npm run build', function (error, stdout, stderr) {
-        if (error === null) {
-          var s3 = new AWS.S3({region: 'eu-west-1'});
-          var filesToUpload = fs.readdirSync(__dirname + '/public');
+      var s3 = new AWS.S3({region: 'eu-west-1'});
+      var filesToUpload = fs.readdirSync(__dirname + '/public');
 
-          console.log('>>>>>>>>> Files:', filesToUpload);
-          console.log('>>>>>>>>> Bucket folder', bucketfolder);
+      console.log('>>>>>>>>> Files:', filesToUpload);
+      console.log('>>>>>>>>> Bucket folder', bucketfolder);
 
-          filesToUpload.forEach(function (filename) {
-            var ContentType = mime.contentType(filename);
-            var params = {
-              Bucket: bucketName,
-              Key: bucketfolder + filename,
-              Body: fs.readFileSync(__dirname + '/public/' + filename),
-              ContentType
-            };
-            s3.putObject(params, function (err, data) {
-              if (err) console.log('Object upload unsuccessful!', err);
-              else console.log('Object ' + filename + ' was created!');
-            });
-          });
-        }
+      filesToUpload.forEach(function (filename) {
+        var ContentType = mime.contentType(filename);
+        var params = {
+          Bucket: bucketName,
+          Key: bucketfolder + filename,
+          Body: fs.readFileSync(__dirname + '/public/' + filename),
+          ContentType
+        };
+        s3.putObject(params, function (err, data) {
+          if (err) console.log('Object upload unsuccessful!', err);
+          else console.log('Object ' + filename + ' was created!');
+        });
+      });
+    }
+  });
+});
+
+gulp.task('prod:deploy', function () {
+  /*
+  * config values
+  *
+  */
+
+  var version = pkg.version;
+  var bucketName = 'www.tcdl.io-prod';
+  var bucketfolder = 'isearch/' + version + '/';
+
+  return exec('npm run prod:build', function (error, stdout, stderr) {
+    if (error === null) {
+      var s3 = new AWS.S3({region: 'eu-west-1'});
+      var filesToUpload = fs.readdirSync(__dirname + '/public');
+
+      console.log('>>>>>>>>> Files:', filesToUpload);
+      console.log('>>>>>>>>> Bucket folder', bucketfolder);
+
+      filesToUpload.forEach(function (filename) {
+        var ContentType = mime.contentType(filename);
+        var params = {
+          Bucket: bucketName,
+          Key: bucketfolder + filename,
+          Body: fs.readFileSync(__dirname + '/public/' + filename),
+          ContentType
+        };
+        s3.putObject(params, function (err, data) {
+          if (err) console.log('Object upload unsuccessful!', err);
+          else console.log('Object ' + filename + ' was created!');
+        });
       });
     }
   });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-register": "^6.6.0",
     "bl": "^1.1.2",
     "chai": "^3.5.0",
-    "con.figure": "0.0.0",
+    "con.figure": "1.0.0",
     "css-loader": "^0.23.1",
     "engine.io-client": "^1.6.9",
     "enzyme": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "nocov": "npm run lib:test && npm run src:test",
     "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha ./test/**/*.test.js ./lib/**/*.test.js --report lcov -- -R spec",
     "clean": "rm -rf public && mkdir -p public/",
-    "build": "npm run clean && ./node_modules/.bin/webpack --optimize-dedupe -p --config ./webpack.production.config.js",
+    "ci:build": "npm run clean && ./node_modules/.bin/webpack --optimize-dedupe -p --config ./webpack.ci.config.js",
+    "prod:build": "npm run clean && ./node_modules/.bin/webpack --optimize-dedupe -p --config ./webpack.production.config.js",
     "stats": "npm run clean && ./node_modules/.bin/webpack --optimize-dedupe -p --config ./webpack.production.config.js --profile --json > public/stats.json",
     "deploy": "gulp deploy",
     "generate-graphql-schema": "babel-node ./test/constants/helpers/update-schema.js > ./test/constants/helpers/schema.json"
@@ -50,6 +51,7 @@
     "babel-register": "^6.6.0",
     "bl": "^1.1.2",
     "chai": "^3.5.0",
+    "con.figure": "0.0.0",
     "css-loader": "^0.23.1",
     "engine.io-client": "^1.6.9",
     "enzyme": "^2.2.0",

--- a/src/history/configure-history.js
+++ b/src/history/configure-history.js
@@ -1,6 +1,3 @@
 import { useRouterHistory } from 'react-router';
 import { createHistory } from 'history';
-import { basename } from '../../config.js';
-export const history = useRouterHistory(createHistory)({
-  basename
-});
+export const history = useRouterHistory(createHistory)();

--- a/src/services/graphql.js
+++ b/src/services/graphql.js
@@ -2,6 +2,11 @@
 
 import fetch from 'isomorphic-fetch';
 import uuid from 'uuid';
+import configure from 'con.figure';
+import configuration from '../../config';
+
+const config = configure(configuration);
+
 /**
 * Express-graphql accepts request with the parameters
 * @{query} - A valid GraphQL query or mutation
@@ -10,7 +15,7 @@ import uuid from 'uuid';
 **/
 
 export function query (query, variables) {
-  return fetch('https://f0uih51vu0.execute-api.eu-west-1.amazonaws.com/ci/graphql', {
+  return fetch(config.graphqlUrl, {
     method: 'POST',
     headers: {
       'Accept': 'application/json',

--- a/src/services/websockets.js
+++ b/src/services/websockets.js
@@ -1,10 +1,11 @@
 import * as SearchResultActions from '../actions/search-results.js';
 import * as TagActions from '../actions/tags.js';
 import Primus from '../../src/services/primus.js';
+import configuration from '../../config';
+import configure from 'con.figure';
 
-// TODO: Switch URL's based on the deployed environment. Maybe by using
-// process.env and the setup within the webpack.config?
-const socketUrl = 'https://ci-socket-server.tcdl.io?auto_room=false';
+const config = configure(configuration);
+
 /**
 * Function that initialises a connection with the web socket server and saves
 * the id to the redux store
@@ -15,7 +16,7 @@ const socketUrl = 'https://ci-socket-server.tcdl.io?auto_room=false';
 */
 
 export function initialise (actionCreatorBinder, location) {
-  const primus = new Primus(socketUrl);
+  const primus = new Primus(config.socketUrl);
   const {
     saveSearchResult,
     saveSocketConnectionId,

--- a/webpack.ci.config.js
+++ b/webpack.ci.config.js
@@ -1,0 +1,57 @@
+'use strict';
+var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+module.exports = {
+  entry: ['./src/index.js'],
+  output: {
+    path: __dirname + '/public/',
+    filename: 'bundle-[hash:6].js'
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        loader: 'babel'
+      },
+      {
+        test: /masonry-layout/,
+        loader: 'imports?define=>false&this=>window'
+      },
+      {
+        test: /imagesloaded/,
+        loader: 'imports?define=>false&this=>window'
+      },
+      {
+        test: /\.(ttf|otf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
+        loader: 'file-loader?name=[name].[ext]'
+      },
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader'
+      },
+      {
+        test: /\.png$/,
+        loader: 'url-loader',
+        query: { mimetype: 'image/png' }
+      }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify('ci')
+      }
+    }),
+    new webpack.NoErrorsPlugin(),
+    new HtmlWebpackPlugin({
+      filename: 'index.html',
+      inject: 'body',
+      template: 'src/index.template.html'
+    }),
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /da/),
+    new webpack.optimize.UglifyJsPlugin({ comments: false })
+  ],
+  colors: true,
+  progress: true
+};


### PR DESCRIPTION
This replaces `npm run build` with `npm run ci:build` and `npm run
prod:build`, this also updates the gulp tasks as well.

As a note this does remove the basename from the router history component. 

This should now use a relative path.