### PR TITLE
Adds react-router-scroll to control scroll behaviour between routes 

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-redux": "^4.4.0",
     "react-router": "^2.3.0",
     "react-router-redux": "^4.0.4",
+    "react-router-scroll": "^0.2.0",
     "react-scroll": "^1.0.15",
     "react-slick": "^0.12.0",
     "react-typeahead": "^1.1.9",

--- a/src/components/hotel/index.js
+++ b/src/components/hotel/index.js
@@ -5,7 +5,6 @@ import capitalize from 'lodash.capitalize';
 import './styles.css';
 
 import ISearchSlider from '../../../lib/image-slider';
-import LoadingSpinner from '../../../lib/spinner';
 
 const heartShareSrc = 'https://cloud.githubusercontent.com/assets/12450298/14609563/3e0af0b6-0582-11e6-9668-d15a38cdea14.png';
 const ratingIconUrl = '../../../src/assets/ratingIcon.png';
@@ -123,8 +122,8 @@ class HotelPage extends Component {
     });
   }
 
-  renderHotelPage () {
-    const { packageOffer, goBack } = this.props;
+  renderHotelPage (props) {
+    const { packageOffer, goBack } = props;
     const hotelImages = packageOffer.hotel.images.large.map(i => i.uri);
     const roundedStarRating = Math.floor(packageOffer.hotel.starRating);
     const image = hotelImages[ 0 ];
@@ -191,15 +190,23 @@ class HotelPage extends Component {
 
   render () {
     const { packageOffer } = this.props;
+    const defaultPackage = {
+      goBack: this.props.goBack,
+      packageOffer: defaultProps.packageOffer
+    };
     if (packageOffer.hotel.description) {
       this.addAnalyticsData();
       return (
         <div className='hotelPageContainer'>
-          {this.renderHotelPage()}
+          {this.renderHotelPage(this.props)}
         </div>
       );
     } else {
-      return <LoadingSpinner />;
+      return (
+        <div className='hotelPageContainer'>
+          {this.renderHotelPage(defaultPackage)}
+        </div>
+      );
     }
   }
 }
@@ -209,6 +216,74 @@ HotelPage.propTypes = {
   getHotel: PropTypes.func,
   params: PropTypes.object,
   packageOffer: PropTypes.object
+};
+
+const defaultProps = {
+  packageOffer: {
+    hotel: {
+      starRating: 0,
+      images: {
+        small: [
+          {
+            uri: ''
+          }
+        ],
+        large: [
+          {
+            uri: ''
+          }
+        ]
+      },
+      name: '',
+      description: '',
+      place: {
+        country: '',
+        region: '',
+        name: ''
+      }
+    },
+    provider: {
+      context: ''
+    },
+    nights: 5,
+    flights: {
+      outbound: [ {
+        departure: {
+          localDateTime: ''
+        }
+      } ],
+      inbound: [ {
+        departure: {
+          localDateTime: ''
+        }
+      } ]
+    },
+    price: {
+      perPerson: ''
+    },
+    amenities: {
+      allinclusive: false,
+      bar: true,
+      childrenpool: true,
+      cleaningdaysperweek: '6',
+      distancetobeach: '300 m',
+      distancetocenter: '200 m',
+      elevator: true,
+      isadulthotel: false,
+      lolloandbernie: false,
+      minimarket: false,
+      outdoorpool: '2 stk.',
+      poolbar: true,
+      restaurant: true,
+      waterslide: false,
+      wifi: true
+    }
+  },
+  params: {
+    bucketId: '12345',
+    itemId: '1234556'
+  },
+  getHotel: () => {}
 };
 
 export default HotelPage;

--- a/src/containers/router.js
+++ b/src/containers/router.js
@@ -2,9 +2,9 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { Provider } from 'react-redux';
-import { Router, Route, IndexRoute, hashHistory } from 'react-router';
+import { Router, Route, IndexRoute, hashHistory, applyRouterMiddleware } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
-
+import useScroll from 'react-router-scroll';
 // components
 import ISearch from '../containers/isearch.js';
 import ArticleFullPage from '../containers/article.js';
@@ -42,13 +42,17 @@ export default class Root extends Component {
     if (this.socket) { this.socket.destroy(); }
   }
 
+  determineScrollBehaviour ({ location: prevLocation }, { location }) {
+    return location.pathname.indexOf('hotel') > -1 ? [0, 0] : true; // scroll to top for hotel route
+  }
+
   render () {
     return (
       <Provider store={store}>
-        <Router history={syncedHistory}>
-          <Route path='/' component={App} ignoreScrollBehavior>
-            <IndexRoute component={ISearch}/>
-            <Route path='search/:bucketId' component={ISearch}/>
+        <Router history={syncedHistory} render={applyRouterMiddleware(useScroll(this.determineScrollBehaviour))}>
+          <Route path='/' component={App}>
+            <IndexRoute component={ISearch} />
+            <Route path='search/:bucketId' component={ISearch} />
             <Route path='article/:bucketId/:itemId' component={ArticleFullPage} />
             <Route path='hotel/:bucketId/:itemId' component={HotelPage} />
             <Route path='destination/:bucketId/:itemId' component={DestinationFullPage} />

--- a/test/components/hotel.test.js
+++ b/test/components/hotel.test.js
@@ -76,8 +76,10 @@ describe('Component', function () {
     it('should render our HotelPage component', function (done) {
       global.dataLayer = [];
       const wrapper = shallow(<HotelPage {...defaultProps} />);
+      const title = wrapper.find('.titlePackage').text();
       const children = wrapper.children().nodes;
       expect(children).to.have.length(4);
+      expect(title).to.equal('Sun Wing');
       done();
     });
     it('should admit a boolean at amenities', function (done) {
@@ -88,12 +90,14 @@ describe('Component', function () {
       expect(children).to.have.length(4);
       done();
     });
-    it('should render a loading spinner if there is no hotel description', function (done) {
+    it('should render the full page with empty contents if there is no hotel description', function (done) {
       global.dataLayer = null;
       const props = { ...defaultProps, packageOffer: { hotel: { description: null } } };
       const wrapper = shallow(<HotelPage {...props} />);
+      const title = wrapper.find('.titlePackage').text();
       const children = wrapper.children().nodes;
-      expect(children).to.have.length(0);
+      expect(children).to.have.length(4);
+      expect(title).to.equal('');
       done();
     });
   });


### PR DESCRIPTION
When the user is on the hotel page, it is scrolled to the top. But scroll position is preserved for all other pages.
 
Also updates hotel page tests

Fixes an issue from #265 