### PR TITLE
dynamic meta title

### DIFF
--- a/src/components/article/index.js
+++ b/src/components/article/index.js
@@ -87,6 +87,7 @@ class ArticleFullPage extends Component {
       const introSection = articleContent.sections[0];
       const content = articleContent.sections.slice(1);
       this.addAnalyticsData();
+      if (document.querySelector('title')) document.querySelector('title').innerHTML = introSection.title;
       return (
         <section>
           <NavHeader backToSearch={goBack}/>

--- a/src/components/hotel/index.js
+++ b/src/components/hotel/index.js
@@ -133,6 +133,7 @@ class HotelPage extends Component {
     const region = packageOffer.hotel.place.region === null ? '' : packageOffer.hotel.place.region + ', ';
     const name = packageOffer.hotel.place.name;
 
+    if (document.querySelector('title')) document.querySelector('title').innerHTML = packageOffer.hotel.name;
     return ([
       <NavHeader backToSearch={goBack}/>,
       <div className='hotelPackageImage' style={{backgroundImage: `url(${image})`}}/>,

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -73,8 +73,8 @@ class ISearch extends Component {
       </ScrollView>
     );
   }
-
   render () {
+    if (document.querySelector('title')) document.querySelector('title').innerHTML = 'ISearch';
     const {
       tags,
       removeTag,


### PR DESCRIPTION
Meta title changed dynamically by `hack`. 

As  it's the only meta to be changed by now, and the change is made on front end, it makes no sense to make something more complex. 
Right now the target is not to satisfy scrappers requirements or improve SEO. And for accomplish this we would need back-end rendering, maybe:  https://github.com/reactjs/redux/blob/master/docs/recipes/ServerRendering.md
https://prerender.io/
https://github.com/Robert-W/react-prerender

So, for now, i think the simpler way is to do like this. And maybe a further step could include something from backend rendering to fit SEO requirements. 