### PR TITLE
Impressions timeout (analytics)

### DIFF
--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -73,17 +73,17 @@ const _getItemId = (item) => _itemIdMapping[item.type](item);
  * Adds analytics data regarding impressions only if there no a previous impression within the last 30 seconds
  * @param item
  * @param dataLayer
- * @param auxDataLayer      Map for tracking last time a search result tile has been viewed by a user.
+ * @param impressionsTimestamp      Map for tracking last time a search result tile has been viewed by a user.
  *                          The key is the item ID and the value the timestamp when the last impression was tracked
  */
-export const addAnalyticsImpression = (item, dataLayer, auxDataLayer) => {
+export const addAnalyticsImpression = (item, dataLayer, impressionsTimestamp) => {
   const itemId = _getItemId(item);
   const currentTimestamp = (new Date()).getTime();
-  // If the element doesn't exists in auxDataLayer it means it has been never displayed to the user. So analytics event
+  // If the element doesn't exists in impressionsTimestamp it means it has been never displayed to the user. So analytics event
   // will be generated.
   // if the last impression was 30 seconds ago or before a new impression analytics event will be launched.
-  if (!auxDataLayer.has(itemId) || currentTimestamp - auxDataLayer.get(itemId) > 30000) {
-    auxDataLayer.set(itemId, currentTimestamp);
+  if (!impressionsTimestamp.has(itemId) || currentTimestamp - impressionsTimestamp.get(itemId) > 30000) {
+    impressionsTimestamp.set(itemId, currentTimestamp);
     dataLayer.push(impresionDataFactory(item));
   }
 };

--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -73,13 +73,17 @@ const _getItemId = (item) => _itemIdMapping[item.type](item);
  * Adds analytics data regarding impressions only if there no a previous impression within the last 30 seconds
  * @param item
  * @param dataLayer
- * @param auxDataLayer
+ * @param auxDataLayer      Map for tracking last time a search result tile has been viewed by a user.
+ *                          The key is the item ID and the value the timestamp when the last impression was tracked
  */
 export const addAnalyticsImpression = (item, dataLayer, auxDataLayer) => {
   const itemId = _getItemId(item);
   const currentTimestamp = (new Date()).getTime();
-  if (!auxDataLayer[itemId] || currentTimestamp - auxDataLayer[itemId] > 30000) { // if the last impression was 30 seconds ago or before
-    auxDataLayer[itemId] = currentTimestamp;
+  // If the element doesn't exists in auxDataLayer it means it has been never displayed to the user. So analytics event
+  // will be generated.
+  // if the last impression was 30 seconds ago or before a new impression analytics event will be launched.
+  if (!auxDataLayer.has(itemId) || currentTimestamp - auxDataLayer.get(itemId) > 30000) {
+    auxDataLayer.set(itemId, currentTimestamp);
     dataLayer.push(impresionDataFactory(item));
   }
 };

--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -82,8 +82,8 @@ export const addAnalyticsImpression = (item, dataLayer, impressionsTimestamp) =>
   // If the element doesn't exists in impressionsTimestamp it means it has been never displayed to the user. So analytics event
   // will be generated.
   // if the last impression was 30 seconds ago or before a new impression analytics event will be launched.
-  if (!impressionsTimestamp.has(itemId) || currentTimestamp - impressionsTimestamp.get(itemId) > 30000) {
-    impressionsTimestamp.set(itemId, currentTimestamp);
+  if (!impressionsTimestamp[itemId] || currentTimestamp - impressionsTimestamp[itemId] > 30000) {
+    impressionsTimestamp[itemId] = currentTimestamp;
     dataLayer.push(impresionDataFactory(item));
   }
 };

--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -78,14 +78,9 @@ const _getItemId = (item) => _itemIdMapping[item.type](item);
 export const addAnalyticsImpression = (item, dataLayer, auxDataLayer) => {
   const itemId = _getItemId(item);
   const currentTimestamp = (new Date()).getTime();
-  if (!auxDataLayer[itemId]) {
+  if (!auxDataLayer[itemId] || currentTimestamp - auxDataLayer[itemId] > 30000) { // if the last impression was 30 seconds ago or before
     auxDataLayer[itemId] = currentTimestamp;
     dataLayer.push(impresionDataFactory(item));
-  } else {
-    if (currentTimestamp - auxDataLayer[itemId] > 30000) { // if the last impression was 30 seconds ago or before
-      auxDataLayer[itemId] = currentTimestamp;
-      dataLayer.push(impresionDataFactory(item));
-    }
   }
 };
 

--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -52,6 +52,44 @@ export const impresionDataFactory = (item) => {
 };
 
 /**
+ * Maps item structure to retrieve the proper analytics id
+ * @type {{package: (function(): string), filter: (function(): string), tile: (function(): (string))}}
+ * @private
+ */
+const _itemIdMapping = {
+  package: (item) => item.packageOffer.provider.reference,
+  filter: (item) => item.id,
+  tile: (item) => item.tile.name
+};
+
+/**
+ * Get the item analytics ID given a search result item
+ * @param item
+ * @private
+ */
+const _getItemId = (item) => _itemIdMapping[item.type](item);
+
+/**
+ * Adds analytics data regarding impressions only if there no a previous impression within the last 30 seconds
+ * @param item
+ * @param dataLayer
+ * @param auxDataLayer
+ */
+export const addAnalyticsImpression = (item, dataLayer, auxDataLayer) => {
+  const itemId = _getItemId(item);
+  const currentTimestamp = (new Date()).getTime();
+  if (!auxDataLayer[itemId]) {
+    auxDataLayer[itemId] = currentTimestamp;
+    dataLayer.push(impresionDataFactory(item));
+  } else {
+    if (currentTimestamp - auxDataLayer[itemId] > 30000) { // if the last impression was 30 seconds ago or before
+      auxDataLayer[itemId] = currentTimestamp;
+      dataLayer.push(impresionDataFactory(item));
+    }
+  }
+};
+
+/**
  * Creates the analytics object for adding a tag
  * @param displayName
  * @param currentTags

--- a/lib/analytics-helper/test/analytics-helper.test.js
+++ b/lib/analytics-helper/test/analytics-helper.test.js
@@ -113,7 +113,7 @@ describe('Analytics helper', function () {
     it('Should add a new impression if there is no previous item impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
-      const impressionsTimestamp = new Map();
+      const impressionsTimestamp = {};
       analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(1);
       done();
@@ -122,22 +122,20 @@ describe('Analytics helper', function () {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date10secsago = (new Date()).getTime() - 10000;
-      const impressionsTimestamp = new Map();
-      impressionsTimestamp.set('fixtureReference', date10secsago);
+      const impressionsTimestamp = {fixtureReference: date10secsago};
       analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(0);
-      expect(impressionsTimestamp.get('fixtureReference')).to.be.equal(date10secsago);
+      expect(impressionsTimestamp.fixtureReference).to.be.equal(date10secsago);
       done();
     });
     it('Should add a new impression if there is more than 30 seconds since last impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date40secsago = (new Date()).getTime() - 40000;
-      const impressionsTimestamp = new Map();
-      impressionsTimestamp.set('fixtureReference', date40secsago);
+      const impressionsTimestamp = {fixtureReference: date40secsago};
       analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(1);
-      expect(impressionsTimestamp.get('fixtureReference')).not.to.be.equal(date40secsago);
+      expect(impressionsTimestamp.fixtureReference).not.to.be.equal(date40secsago);
       done();
     });
   });

--- a/lib/analytics-helper/test/analytics-helper.test.js
+++ b/lib/analytics-helper/test/analytics-helper.test.js
@@ -113,7 +113,7 @@ describe('Analytics helper', function () {
     it('Should add a new impression if there is no previous item impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
-      const auxDataLayer = {};
+      const auxDataLayer = new Map();
       analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
       expect(dataLayer).to.have.length(1);
       done();
@@ -122,20 +122,22 @@ describe('Analytics helper', function () {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date10secsago = (new Date()).getTime() - 10000;
-      const auxDataLayer = {fixtureReference: date10secsago};
+      const auxDataLayer = new Map();
+      auxDataLayer.set('fixtureReference', date10secsago);
       analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
       expect(dataLayer).to.have.length(0);
-      expect(auxDataLayer.fixtureReference).to.be.equal(date10secsago);
+      expect(auxDataLayer.get('fixtureReference')).to.be.equal(date10secsago);
       done();
     });
     it('Should add a new impression if there is more than 30 seconds since last impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date40secsago = (new Date()).getTime() - 40000;
-      const auxDataLayer = {fixtureReference: date40secsago};
+      const auxDataLayer = new Map();
+      auxDataLayer.set('fixtureReference', date40secsago);
       analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
       expect(dataLayer).to.have.length(1);
-      expect(auxDataLayer.fixtureReference).not.to.be.equal(date40secsago);
+      expect(auxDataLayer.get('fixtureReference')).not.to.be.equal(date40secsago);
       done();
     });
   });

--- a/lib/analytics-helper/test/analytics-helper.test.js
+++ b/lib/analytics-helper/test/analytics-helper.test.js
@@ -113,8 +113,8 @@ describe('Analytics helper', function () {
     it('Should add a new impression if there is no previous item impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
-      const auxDataLayer = new Map();
-      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      const impressionsTimestamp = new Map();
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(1);
       done();
     });
@@ -122,22 +122,22 @@ describe('Analytics helper', function () {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date10secsago = (new Date()).getTime() - 10000;
-      const auxDataLayer = new Map();
-      auxDataLayer.set('fixtureReference', date10secsago);
-      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      const impressionsTimestamp = new Map();
+      impressionsTimestamp.set('fixtureReference', date10secsago);
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(0);
-      expect(auxDataLayer.get('fixtureReference')).to.be.equal(date10secsago);
+      expect(impressionsTimestamp.get('fixtureReference')).to.be.equal(date10secsago);
       done();
     });
     it('Should add a new impression if there is more than 30 seconds since last impression', function (done) {
       const item = fixtures.package.item;
       const dataLayer = [];
       const date40secsago = (new Date()).getTime() - 40000;
-      const auxDataLayer = new Map();
-      auxDataLayer.set('fixtureReference', date40secsago);
-      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      const impressionsTimestamp = new Map();
+      impressionsTimestamp.set('fixtureReference', date40secsago);
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
       expect(dataLayer).to.have.length(1);
-      expect(auxDataLayer.get('fixtureReference')).not.to.be.equal(date40secsago);
+      expect(impressionsTimestamp.get('fixtureReference')).not.to.be.equal(date40secsago);
       done();
     });
   });

--- a/lib/analytics-helper/test/analytics-helper.test.js
+++ b/lib/analytics-helper/test/analytics-helper.test.js
@@ -109,4 +109,34 @@ describe('Analytics helper', function () {
       done();
     });
   });
+  describe('Add analytics Impression objects', function () {
+    it('Should add a new impression if there is no previous item impression', function (done) {
+      const item = fixtures.package.item;
+      const dataLayer = [];
+      const auxDataLayer = {};
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      expect(dataLayer).to.have.length(1);
+      done();
+    });
+    it('Should not add a new impression if there is already one within the last 30 seconds', function (done) {
+      const item = fixtures.package.item;
+      const dataLayer = [];
+      const date10secsago = (new Date()).getTime() - 10000;
+      const auxDataLayer = {fixtureReference: date10secsago};
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      expect(dataLayer).to.have.length(0);
+      expect(auxDataLayer.fixtureReference).to.be.equal(date10secsago);
+      done();
+    });
+    it('Should add a new impression if there is more than 30 seconds since last impression', function (done) {
+      const item = fixtures.package.item;
+      const dataLayer = [];
+      const date40secsago = (new Date()).getTime() - 40000;
+      const auxDataLayer = {fixtureReference: date40secsago};
+      analyticsHelper.addAnalyticsImpression(item, dataLayer, auxDataLayer);
+      expect(dataLayer).to.have.length(1);
+      expect(auxDataLayer.fixtureReference).not.to.be.equal(date40secsago);
+      done();
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       "window",
       "localStorage",
       "$",
-      "auxDataLayer"
+      "impressionsTimestamp"
     ],
     "parser": "babel-eslint"
   }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
       "primus",
       "window",
       "localStorage",
-      "$"
+      "$",
+      "auxDataLayer"
     ],
     "parser": "babel-eslint"
   }

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -5,7 +5,7 @@ import PackageTile from '../../../lib/package-tile';
 import ArticleTile from '../../../lib/article-tile';
 import VisibilitySensor from 'react-visibility-sensor';
 import DestinationTile from '../../../lib/destination-tile';
-import { impresionDataFactory } from '../../../lib/analytics-helper/index';
+import { addAnalyticsImpression } from '../../../lib/analytics-helper/index';
 
 const removeTileButton = require('../../assets/cancel.svg');
 import './style.css';
@@ -35,7 +35,7 @@ class SearchResults extends Component {
     if (!dataLayer || !isVisible) {
       return;
     }
-    dataLayer.push(impresionDataFactory(item));
+    addAnalyticsImpression(item, dataLayer, auxDataLayer);
     return;
   }
 

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -35,7 +35,7 @@ class SearchResults extends Component {
     if (!dataLayer || !isVisible) {
       return;
     }
-    addAnalyticsImpression(item, dataLayer, auxDataLayer);
+    addAnalyticsImpression(item, dataLayer, impressionsTimestamp);
     return;
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    auxDataLayer = new Map(); // this datalayer will be used to track impressions timeouts
+    impressionsTimestamp = new Map(); // this map will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    auxDataLayer = {}; // this datalayer will be used to track impressions timeouts
+    auxDataLayer = new Map(); // this datalayer will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    impressionsTimestamp = new Map(); // this map will be used to track impressions timeouts
+    impressionsTimestamp = {}; // this map will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.html
+++ b/src/index.html
@@ -30,10 +30,10 @@
         'initial_search_month': (URL_PARAMS.departure_date && URL_PARAMS.departure_date.indexOf('-') > -1) ? URL_PARAMS.departure_date.split('-')[ 1 ] : '',
         'initial_search_year': (URL_PARAMS.departure_date && URL_PARAMS.departure_date.indexOf('-') > -1) ? URL_PARAMS.departure_date.split('-')[ 0 ] : '2016'
       };
-      console.log(event);
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
+    auxDataLayer = {}; // this datalayer will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    auxDataLayer = new Map(); // this datalayer will be used to track impressions timeouts
+    impressionsTimestamp = new Map(); // this map will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    auxDataLayer = {}; // this datalayer will be used to track impressions timeouts
+    auxDataLayer = new Map(); // this datalayer will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -30,10 +30,10 @@
         'initial_search_month': (URL_PARAMS.departure_date && URL_PARAMS.departure_date.indexOf('-') > -1) ? URL_PARAMS.departure_date.split('-')[1] : '',
         'initial_search_year': (URL_PARAMS.departure_date && URL_PARAMS.departure_date.indexOf('-') > -1) ? URL_PARAMS.departure_date.split('-')[0] : '2016'
       };
-      console.log(event);
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
+    auxDataLayer = {}; // this datalayer will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/src/index.template.html
+++ b/src/index.template.html
@@ -33,7 +33,7 @@
       dataLayer.push(event);
     }
     console.log('Google Tag Manager Initialised');
-    impressionsTimestamp = new Map(); // this map will be used to track impressions timeouts
+    impressionsTimestamp = {}; // this map will be used to track impressions timeouts
     </script>
 
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-53SBVW"

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -12,14 +12,14 @@ import sinon from 'sinon';
 
 describe('Component', function () {
   global.dataLayer = [];
-  global.impressionsTimestamp = new Map();
+  global.impressionsTimestamp = {};
   describe('<SearchResults />', function () {
     const removeStub = sinon.stub();
     const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
     beforeEach(() => {
       removeStub.reset();
       global.dataLayer = [];
-      global.impressionsTimestamp = new Map();
+      global.impressionsTimestamp = {};
     });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -12,12 +12,14 @@ import sinon from 'sinon';
 
 describe('Component', function () {
   global.dataLayer = [];
+  global.auxDataLayer = {};
   describe('<SearchResults />', function () {
     const removeStub = sinon.stub();
     const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
     beforeEach(() => {
       removeStub.reset();
       global.dataLayer = [];
+      global.auxDataLayer = {};
     });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -12,14 +12,14 @@ import sinon from 'sinon';
 
 describe('Component', function () {
   global.dataLayer = [];
-  global.auxDataLayer = new Map();
+  global.impressionsTimestamp = new Map();
   describe('<SearchResults />', function () {
     const removeStub = sinon.stub();
     const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
     beforeEach(() => {
       removeStub.reset();
       global.dataLayer = [];
-      global.auxDataLayer = new Map();
+      global.impressionsTimestamp = new Map();
     });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -12,14 +12,14 @@ import sinon from 'sinon';
 
 describe('Component', function () {
   global.dataLayer = [];
-  global.auxDataLayer = {};
+  global.auxDataLayer = new Map();
   describe('<SearchResults />', function () {
     const removeStub = sinon.stub();
     const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} removeTile={removeStub} />);
     beforeEach(() => {
       removeStub.reset();
       global.dataLayer = [];
-      global.auxDataLayer = {};
+      global.auxDataLayer = new Map();
     });
     it('should render our SearchResults component', function (done) {
       const children = wrapper.children().nodes;


### PR DESCRIPTION
Consecutive tiles impressions will not be tracked unless there is more than 30 secs between impressions. 

Closes #309 