### PR TITLE
Updates gulp script to create and push tag on gulp prod deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ gulp prod:deploy
 
 The contents of the public folder will then be uploaded to the specified Amazon S3 bucket. Have a look at the 'gulpfile.js' for implementation details.
 
+### Deploying to Production
+
+When the gulp task `prod:deploy` is called, a git tag is created based on the version number in the `package.json`. If a tag for that version exists, an error is shown. Once the tag has been created, it is pushed to github and the code is deployed to s3. Rollbacks can be done more easily if all production deployments have an associated artifict in the form of a git tag. Github _releases_ still need to be created manually from the tags. 
+
 # APPENDIX
 
 ## Setting up the React Webpack Babel Project

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,10 +15,6 @@ var version = pkg.version.split('.')[2]; // using the patch version number
 var bucketName = 'www.tcdl.io';
 var bucketfolder = 'isearch/0.' + version + '/';
 
-/**
- * building the bundle
- */
-
 gulp.task('ci:deploy', function () {
   return exec('npm run ci:build', function (error, stdout, stderr) {
     if (error === null) {
@@ -45,15 +41,29 @@ gulp.task('ci:deploy', function () {
   });
 });
 
+function createTag (next) {
+  const cmd = 'git tag v' + pkg.version;
+  exec(cmd, function (error, stdout, stderr) {
+    if (error.message.includes('already exists')) {
+      console.log('tag for version', pkg.version, ' already exists. Update version in package.json and re run the deployment script');
+      return;
+    } else {
+      next();
+    }
+  });
+}
+
 gulp.task('prod:deploy', function () {
+  return createTag(deployProd);
+});
+
+function deployProd () {
   /*
-  * config values
-  *
+  * config
   */
-
   var bucketfolder = 'isearch/prod/';
-
-  return exec('npm run prod:build', function (error, stdout, stderr) {
+  const cmd = 'git push origin v' + pkg.version + ' && npm run prod:build';
+  return exec(cmd, function (error, stdout, stderr) {
     if (error === null) {
       var s3 = new AWS.S3({region: 'eu-west-1'});
       var filesToUpload = fs.readdirSync(__dirname + '/public');
@@ -80,4 +90,4 @@ gulp.task('prod:deploy', function () {
       });
     }
   });
-});
+}


### PR DESCRIPTION
From the tag, the release still needs to be created manually - as far as I am aware, releases can only be created using the Github API.

fixes #319 