### PR TITLE
Don't git tag prod deployments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,8 +43,8 @@ gulp.task('ci:deploy', function () {
 
 function createTag (next) {
   const cmd = 'git tag v' + pkg.version;
-  exec(cmd, function (error, stdout, stderr) {
-    if (error.message.includes('already exists')) {
+  exec(cmd, function (err, stdout, stderr) {
+    if (err && err.message.includes('already exists')) {
       console.log('tag for version', pkg.version, ' already exists. Update version in package.json and re run the deployment script');
       return;
     } else {


### PR DESCRIPTION
~~Problem: tagging on deploying to production will fail because there'll already be a tag created by a ci deployment.~~

~~Solution: don't tag prod deployment. (prod deployments are tracked my merged into `prod`)~~

We just need to not fail when there's no error.