### PR TITLE
Support an automatic search tag based on query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lodash.union": "^4.4.0",
     "lodash.uniqby": "^4.5.0",
     "moment": "^2.12.0",
+    "querystring": "^0.2.0",
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-google-maps": "^4.11.0",

--- a/src/actions/tags.js
+++ b/src/actions/tags.js
@@ -6,8 +6,11 @@ import {
   CLEAR_SEARCH_STRING,
   RESET_TAGS
 } from '../constants/actionTypes';
+import * as graphqlService from '../services/graphql';
 import { startSearch } from './search-results.js';
 import { analyticsAddTagObject, analyticsRemoveTagObject } from '../../lib/analytics-helper';
+
+import { QUERY_AUTOCOMPLETE_INPUT } from '../constants/queries.js';
 
 /**
 * TEMP FUNCTIONS TO ADD MOCK TAGS
@@ -51,6 +54,25 @@ export function deleteTag (displayName) {
 
 export const onYesFilter = (displayName, id) => (dispatch) => {
   return dispatch(addSingleTag(displayName, id, 'filter'));
+};
+
+export const searchForTag = (searchString) => (dispatch) => {
+  const variables = {
+    input: searchString,
+    size: 1
+  };
+  graphqlService
+    .query(QUERY_AUTOCOMPLETE_INPUT, variables)
+    .then(json => {
+      console.log('Autocomplete response', json);
+      const { data: { viewer: { autocomplete } } } = json;
+      if (autocomplete && autocomplete.items && autocomplete.items.length) {
+        const tag = autocomplete.items[0];
+        dispatch(addSingleTag(tag.label, tag.tagid));
+      } else {
+        dispatch(resetTags());
+      }
+    });
 };
 
 /**

--- a/src/services/websockets.js
+++ b/src/services/websockets.js
@@ -3,6 +3,7 @@ import * as TagActions from '../actions/tags.js';
 import Primus from '../../src/services/primus.js';
 import configuration from '../../config';
 import configure from 'con.figure';
+import querystring from 'querystring';
 
 const config = configure(configuration);
 
@@ -21,6 +22,7 @@ export function initialise (actionCreatorBinder, location) {
     saveSearchResult,
     saveSocketConnectionId,
     resetTags,
+    searchForTag,
     setSearchComplete
   } = actionCreatorBinder({...SearchResultActions, ...TagActions});
   primus.on('data', function received (data) {
@@ -44,7 +46,14 @@ export function initialise (actionCreatorBinder, location) {
       var hotelPage = location.indexOf('hotel') > -1;
       var articlePage = location.indexOf('article') > -1;
       var isHomePage = (!hotelPage && !articlePage);
-      if (isHomePage) resetTags();
+      if (isHomePage) {
+        const query = querystring.parse(window.location.search.replace(/^\?/, ''));
+        if (query.search) {
+          return searchForTag(query.search);
+        } else {
+          return resetTags();
+        }
+      }
     });
   });
 

--- a/src/services/websockets.js
+++ b/src/services/websockets.js
@@ -3,7 +3,7 @@ import * as TagActions from '../actions/tags.js';
 import Primus from '../../src/services/primus.js';
 import configuration from '../../config';
 import configure from 'con.figure';
-import querystring from 'querystring';
+import querystring from '../utils/querystring';
 
 const config = configure(configuration);
 
@@ -47,7 +47,7 @@ export function initialise (actionCreatorBinder, location) {
       var articlePage = location.indexOf('article') > -1;
       var isHomePage = (!hotelPage && !articlePage);
       if (isHomePage) {
-        const query = querystring.parse(window.location.search.replace(/^\?/, ''));
+        const query = querystring.parse();
         if (query.search) {
           return searchForTag(query.search);
         } else {

--- a/src/utils/querystring.js
+++ b/src/utils/querystring.js
@@ -1,0 +1,5 @@
+import querystring from 'querystring';
+
+export default {
+  parse: () => querystring.parse(window.location.search.replace(/^\?/, ''))
+};

--- a/test/services/websockets.test.js
+++ b/test/services/websockets.test.js
@@ -4,10 +4,11 @@ import thunk from 'redux-thunk';
 import simple from 'simple-mock';
 import { bindActionCreators } from 'redux';
 import { SAVE_SOCKET_CONNECTION_ID, RESET_TAGS } from '../../src/constants/actionTypes';
+import querystring from '../../src/utils/querystring';
+import * as tagActions from '../../src/actions/tags';
 // mock redux store
 import configureMockStore from '../actions/test-helpers';
 const mockStore = configureMockStore([thunk]);
-import querystring from '../../src/utils/querystring';
 
 describe('Web Socket Service', function () {
   afterEach(() => {
@@ -44,12 +45,15 @@ describe('Web Socket Service', function () {
   });
   it('performs an autocomplete lookup for a default tag if a query string search parameter is provided', () => {
     simple.mock(querystring, 'parse').returnWith({ search: 'family' });
+    simple.mock(tagActions, 'searchForTag');
     const store = mockStore({search: { tags: [], resultId: '1234' }});
     const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
     const primus = initialise(actionCreatorBinder, 'search');
     primus.id = (cb) => { cb('abc123'); };
     primus.emit('open');
     expect(store.getActions()).not.to.contain({ type: RESET_TAGS });
+    expect(tagActions.searchForTag.called).to.be.true;
+    expect(tagActions.searchForTag.lastCall.args[0]).to.equal('family');
   });
   it('only calls the saveSocketConnectionId action on first connection', () => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});

--- a/test/services/websockets.test.js
+++ b/test/services/websockets.test.js
@@ -7,8 +7,12 @@ import { SAVE_SOCKET_CONNECTION_ID, RESET_TAGS } from '../../src/constants/actio
 // mock redux store
 import configureMockStore from '../actions/test-helpers';
 const mockStore = configureMockStore([thunk]);
+import querystring from '../../src/utils/querystring';
 
 describe('Web Socket Service', function () {
+  afterEach(() => {
+    simple.restore();
+  });
   it('calls the saveSocketConnectionId action when connection is opened', () => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});
     const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
@@ -37,6 +41,15 @@ describe('Web Socket Service', function () {
       }
     ];
     expect(store.getActions()).to.deep.equal(expectedActions);
+  });
+  it('performs an autocomplete lookup for a default tag if a query string search parameter is provided', () => {
+    simple.mock(querystring, 'parse').returnWith({ search: 'family' });
+    const store = mockStore({search: { tags: [], resultId: '1234' }});
+    const actionCreatorBinder = actions => bindActionCreators(actions, store.dispatch);
+    const primus = initialise(actionCreatorBinder, 'search');
+    primus.id = (cb) => { cb('abc123'); };
+    primus.emit('open');
+    expect(store.getActions()).not.to.contain({ type: RESET_TAGS });
   });
   it('only calls the saveSocketConnectionId action on first connection', () => {
     const store = mockStore({search: { tags: [], resultId: '1234' }});


### PR DESCRIPTION
If the search is loaded with a `?search=<term>` query string parameter then do an autocomplete lookup based on the search term provided, and if a result is returned then use that as the "default" search term on initial load instead of the "Top inspiration" tag.