### PR TITLE
Set empty defaults for searches

### DIFF
--- a/src/actions/helpers.js
+++ b/src/actions/helpers.js
@@ -97,7 +97,7 @@ export function combinePassengersForQuery (childAgeArray, numberOfChildren, numb
 export function constructTravelPeriodQuery (departureDate, duration) {
   const nights = (Number(duration.split(' ')[0]) * 7);
   const travelPeriod = {
-    departureBetween: [departureDate],
+    departureBetween: departureDate ? [departureDate] : [],
     nights: [nights]
   };
   return travelPeriod;
@@ -110,6 +110,6 @@ export function constructTravelPeriodQuery (departureDate, duration) {
 export function constructDepartureAirportQuery (departureAirport) {
   const airportCode = departureAirport.split(' ')[2];
   const departureAirportMapped = `airport:master.${airportCode}`;
-  const airport = [departureAirportMapped];
+  const airport = airportCode ? [departureAirportMapped] : [];
   return airport;
 }

--- a/src/components/edit-details/index.js
+++ b/src/components/edit-details/index.js
@@ -3,6 +3,8 @@ import DropDown from '../../../lib/select-drop-down';
 import Calendar from '../../../lib/date-picker';
 import { Link } from 'react-router';
 import '../../../lib/react-date-picker/css/index.css';
+import moment from 'moment';
+import departOnFriday from '../../utils/departure-day-format';
 const travelInfoExitButton = require('../../../src/assets/close-white.svg');
 import goBackBrowserDetect from '../../utils/browser-detection';
 
@@ -87,7 +89,7 @@ export default class EditDetails extends Component {
               label={'TIDLIGASTE AFREJSE'}
               setValue={setDepartureDate}
               optionsTitle={'-'}
-              date={departureDate}
+              date={departureDate || departOnFriday(moment().add(3, 'months')).format('YYYY-MM-DD')}
             />
             <DropDown
               width={'22.5%'}

--- a/src/components/edit-details/options.js
+++ b/src/components/edit-details/options.js
@@ -1,24 +1,24 @@
 export const adultOptions = [1, 2, 3, 4, 5, 6];
 export const childOptions = [0, 1, 2, 3, 4];
-export const departureOptions = ['København - CPH', 'Billund - BLL', 'Aalborg - AAL', 'Odense - ODE', 'Rønne - RNN'];
+export const departureOptions = ['Overalt', 'København - CPH', 'Billund - BLL', 'Aalborg - AAL', 'Odense - ODE', 'Rønne - RNN'];
 export const durationOptions = ['1 uge', '2 uger', '3 uger', '4 uger'];
 export const childAgeOptions = [
-  '0 years',
-  '1 year',
-  '2 years',
-  '3 years',
-  '4 years',
-  '5 years',
-  '6 years',
-  '7 years',
-  '8 years',
-  '9 years',
-  '10 years',
-  '11 years',
-  '12 years',
-  '13 years',
-  '14 years',
-  '15 years',
-  '16 years',
-  '17 years'
+  '0 år',
+  '1 år',
+  '2 år',
+  '3 år',
+  '4 år',
+  '5 år',
+  '6 år',
+  '7 år',
+  '8 år',
+  '9 år',
+  '10 år',
+  '11 år',
+  '12 år',
+  '13 år',
+  '14 år',
+  '15 år',
+  '16 år',
+  '17 år'
 ];

--- a/src/reducers/travel-info.js
+++ b/src/reducers/travel-info.js
@@ -1,6 +1,4 @@
 'use strict';
-import moment from 'moment';
-import departOnFriday from '../utils/departure-day-format';
 import {
   SET_CHILD_AGE,
   SET_NUMBER_OF_ADULTS,
@@ -18,9 +16,9 @@ export const initialState = {
   childAge2: '4 Barns alder',
   childAge3: '0 Barns alder',
   childAge4: '0 Barns alder',
-  departureAirport: 'Copenhagen - CPH',
+  departureAirport: 'Overalt',
   duration: '1 uge',
-  departureDate: departOnFriday(moment().add(3, 'months')).format('YYYY-MM-DD'),
+  departureDate: '',
   passengerBirthdays: [],
   numberOfChildrenTitle: '0',
   numberOfAdultsTitle: '2',


### PR DESCRIPTION
This commit sets the departure date, as well as the departure airport to
nothing. The consequence of this is that a broader set of searches
return until the user decides to modify their search.
Improving the result set.

Fixes #361 