### PR TITLE
remove url params if exists

### DIFF
--- a/src/containers/router.js
+++ b/src/containers/router.js
@@ -34,6 +34,7 @@ export default class Root extends Component {
 
   componentWillMount () {
     let currentPath = store.getState().routing.locationBeforeTransitions.pathname;
+    window.history.replaceState('', '', currentPath);
     this.socket = websocketService.initialise(actionCreatorBinder, currentPath);
     fingerprintService.initialise(actionCreatorBinder);
   }


### PR DESCRIPTION
This "hack" will remove query from URL and Philip has to tell me if it has the result we were looking for.

With this, while accessing a url like `http://inspirationalsearch.spies.dk/isearch/1.0.22/?utm_source=test1&utm_medium=test2&utm_name=test3` the url will be replaced with `http://inspirationalsearch.spies.dk/isearch/1.0.22/#/?_k=824y0d`. 


GA is suppose to work now and we are avoiding having the urls like `http://inspirationalsearch.spies.dk/isearch/1.0.22/?utm_source=test1&utm_medium=test2&utm_name=test3/#/?_k=824y0d`
 or 
`http://inspirationalsearch.spies.dk/isearch/1.0.22/?utm_source=test1&utm_medium=test2&utm_name=test3/#/hotel/f4bb9de0-43a5-11e6-9aec-075863570e8d/PMICANP?_k=lxudpd`


Changing the routing would be expensive. I will open a issue describing what's happening with routing. 