### PR TITLE
Restore tests for scroll view component

### DIFF
--- a/lib/scroll-view/index.js
+++ b/lib/scroll-view/index.js
@@ -52,14 +52,16 @@ class ScrollView extends Component {
     this.page = nextProps.page;
   }
 
-  _scrollHandler () {
-    const { loadingThreshold, loadData, endScroll } = this.props;
+  nodeOffset () {
     const node = this._scrollView;
     const nodeHeight = node.offsetHeight; // height of the element
-    const nodeOffsetFromWindowTop = findNodeOffsetFromWindowTop(node); // y displacement of the top of the node from the top of the window
-    const pageYScrollPosition = window.pageYOffset; // scroll position of the top of the page from the top of the window
-    const viewportHeight = window.innerHeight; // height of the viewport
-    const nodeOffsetFromWindowBottom = nodeOffsetFromWindowTop + nodeHeight - pageYScrollPosition - viewportHeight; // offset of the node from the bottom of the window
+    const fromTop = this.props.getNodeOffset(node); // y displacement of the top of the node from the top of the window
+    return fromTop + nodeHeight - window.pageYOffset - window.innerHeight; // offset of the node from the bottom of the window
+  }
+
+  _scrollHandler () {
+    const { loadingThreshold, loadData, endScroll } = this.props;
+    const nodeOffsetFromWindowBottom = this.nodeOffset();
     if (!endScroll && (nodeOffsetFromWindowBottom < loadingThreshold)) { // almost reached the bottom of the scrollView container so call the loadData function prop
       // remove the scroll listener until the component has updated to prevent unecessary calls to the load more function before new data has been loaded
       // scroll listeners added back on componentDidUpdate
@@ -86,12 +88,14 @@ ScrollView.defaultProps = {
   loadingThreshold: 200,
   endScroll: false,
   loadData: () => console.log('Pass in a function to load more data given a page number'),
+  getNodeOffset: findNodeOffsetFromWindowTop,
   page: 0
 };
 
 ScrollView.propTypes = {
   loadingThreshold: PropTypes.number,
   loadData: PropTypes.func,
+  getNodeOffset: PropTypes.func,
   endScroll: PropTypes.bool,
   children: PropTypes.object,
   page: PropTypes.number // scroll page

--- a/lib/scroll-view/test/index.test.js
+++ b/lib/scroll-view/test/index.test.js
@@ -3,31 +3,26 @@ import { mount } from 'enzyme';
 import ScrollView from '../';
 import expect from 'expect';
 
-describe.skip('<ScrollView /> Test', () => {
-  it('Load data is called when nodeOffsetFromWindowBottom is less that the loading threshold', (done) => {
-    const loadData = sinon.spy();
-    const wrapper = mount(<ScrollView loadData={loadData}><p>Test</p></ScrollView>);
-    const node = wrapper.find('div');
-    node.node.offsetTop = 50;
-    node.node.offsetHeight = 100;
+describe('<ScrollView /> Test', () => {
+  beforeEach(() => {
     document.body.scrollTop = 100;
     window.innerHeight = 500;
     window.pageYOffset = 50;
-    window.dispatchEvent(new window.UIEvent('scroll', { deltaY: 50 }));
+  });
+  it('Load data is called when nodeOffsetFromWindowBottom is less that the loading threshold', (done) => {
+    const loadData = sinon.stub();
+    const getNodeOffset = sinon.stub().returns(100);
+    mount(<ScrollView loadData={loadData} getNodeOffset={getNodeOffset}><p>Test</p></ScrollView>);
+    window.dispatchEvent(new window.Event('scroll', { deltaY: 50 }));
     expect(loadData.callCount).toEqual(1);
     expect(loadData.lastCall.args).toEqual([1]);
     done();
   });
   it('Load data is not called when the nodeOffsetFromWindowBottom is greater that the loading threshold', (done) => {
     const loadData = sinon.spy();
-    const wrapper = mount(<ScrollView loadData={loadData}><p>Test</p></ScrollView>);
-    const node = wrapper.find('div');
-    node.node.offsetTop = 50;
-    node.node.offsetHeight = 800;  // scroll view already has lots of elements loaded
-    document.body.scrollTop = 100;
-    window.innerHeight = 500;
-    window.pageYOffset = 50;
-    window.dispatchEvent(new window.UIEvent('scroll', { deltaY: 10 }));
+    const getNodeOffset = sinon.stub().returns(900);
+    mount(<ScrollView loadData={loadData} getNodeOffset={getNodeOffset}><p>Test</p></ScrollView>);
+    window.dispatchEvent(new window.Event('scroll', { deltaY: 10 }));
     expect(loadData.callCount).toEqual(0);
     done();
   });


### PR DESCRIPTION
Replace manually setting DOM element properties in test setup with a replaceable method for determining the position of a node, which can then be stubbed for test purposes.

Test was disabled in #373, this restores it in a way that is compatible with phantomjs.