### PR TITLE
Reset tags to default when removing last tag

### DIFF
--- a/lib/tags/index.js
+++ b/lib/tags/index.js
@@ -10,8 +10,12 @@ export default class TagContainer extends Component {
     this.props.resetTags();
   }
 
+  isNonDefaultTag (tag) {
+    return tag.id !== DEFAULT_TAG.id;
+  }
+
   resetButtonVisibility () {
-    return this.props.tags.filter(tag => tag.id !== DEFAULT_TAG.id).length ? '' : 'hidden';
+    return this.props.tags.filter(this.isNonDefaultTag).length ? '' : 'hidden';
   }
 
   render () {
@@ -25,7 +29,7 @@ export default class TagContainer extends Component {
       border: '1px solid' + resetColour
     };
 
-    var tagComponents = tags.map(function (tag) {
+    var tagComponents = tags.filter(this.isNonDefaultTag).map(function (tag) {
       const type = tag.id.split(':')[0];
       const colour = type === 'geo' ? '#CEC947' : '#8EB8C4';
       return <Tag

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -121,13 +121,19 @@ export default function search (state = initialState, action) {
         isInitialTag: action.isInitialTag
       };
     case TAG_REMOVE_TAG:
-      const newTags = state.tags.filter(tag => {
+      let newTags = state.tags.filter(tag => {
         return tag.displayName !== action.displayName;
       });
+      let isInitialTag = false;
+      if (newTags.length === 0) {
+        newTags = [initialState.defaultTag];
+        isInitialTag = true;
+      }
       return {
         ...state,
         tags: newTags,
-        error: ''
+        error: '',
+        isInitialTag
       };
     case RESET_TAGS:
       return {

--- a/test/reducers/search.test.js
+++ b/test/reducers/search.test.js
@@ -265,13 +265,28 @@ describe('Search Reducer', () => {
     it('TAG_REMOVE_TAG -> removes action.tag from the tags array', (done) => {
       const initialStateWithTags = {
         ...initialState,
+        tags: [{ displayName: 'hello' }, { displayName: 'world' }]
+      };
+      const action = {type: TAG_REMOVE_TAG, displayName: 'hello'};
+      const state = reducer(initialStateWithTags, action);
+      const expectedState = {
+        ...initialState,
+        tags: [{ displayName: 'world' }]
+      };
+      expect(state).to.deep.equal(expectedState);
+      done();
+    });
+    it('TAG_REMOVE_TAG -> resets to default tags if removing the only tag', (done) => {
+      const initialStateWithTags = {
+        ...initialState,
         tags: [{ displayName: 'hello' }]
       };
       const action = {type: TAG_REMOVE_TAG, displayName: 'hello'};
       const state = reducer(initialStateWithTags, action);
       const expectedState = {
         ...initialState,
-        tags: []
+        tags: [initialState.defaultTag],
+        isInitialTag: true
       };
       expect(state).to.deep.equal(expectedState);
       done();


### PR DESCRIPTION
If there is one tag in place, and the user clicks the remove button then set the tags and search back to the default state.

Remove the remove button from the "Top inspiration" tag so that this cannot be removed.

Closes #412 