### PR TITLE
Simplify code for uniqueness check of related items

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -171,15 +171,9 @@ class SearchResults extends Component {
     } = this.props;
     const searchItems = items.filter(item => !item.related);
     const relatedItems = items.filter(item => item.related && item.type !== 'filter');
-    const searchItemIds = [];
-    const relatedItemIds = [];
+    const searchItemIds = searchItems.map(item => item.id);
     const uniqueRelatedItems = relatedItems.filter((obj, index) => {
-      searchItemIds.push(searchItems[index].id);
-      relatedItemIds.push(obj.id);
-      const uniqueIdArray = relatedItemIds.filter(relatedItem => {
-        return searchItemIds.indexOf(relatedItem) === -1;
-      });
-      return uniqueIdArray.indexOf(obj.id);
+      return searchItemIds.indexOf(obj.id) === -1;
     });
     // we might want to have this depend on the browser language at some point:
     // const message = searchItems.length > 0 ? 'You might also be interested in...' : `Looks like we don't have any results that match your search. But you might be interested in...`;
@@ -187,7 +181,7 @@ class SearchResults extends Component {
       ? 'Måske er du også interesseret i…'
       : `Din søgning gav ingen resultater, men måske er du interesseret i…`;
     // see: https://github.com/numo-labs/isearch-ui/issues/257
-    if (((feedEnd && searchComplete) || (searchItems.length === 0 && searchComplete)) && relatedItems.length > 0) {
+    if (((feedEnd && searchComplete) || (searchItems.length === 0 && searchComplete)) && uniqueRelatedItems.length > 0) {
       return (
         [<div key={'message'} className='feed-end-message'>{message}</div>,
         <Masonry


### PR DESCRIPTION
Creates an array of ids that exist in the main search result set, then filters the related results checking if their id exists within that set.

Fixes a bug where the filter would fail and throw an error if the length of the related results was longer than the main results set.