### PR TITLE
rerender search results if searchComplete changes

### DIFF
--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -24,7 +24,7 @@ class SearchResults extends Component {
     this.getRelatedContent = this.getRelatedContent.bind(this);
   }
   shouldComponentUpdate (nextProps) {
-    if (nextProps.items.length === this.props.items.length) {
+    if (nextProps.items.length === this.props.items.length && nextProps.searchComplete === this.props.searchComplete) {
       return false;
     } else {
       return true;


### PR DESCRIPTION
Fixes "might like" scroll issue. 

Search results pane was not being rerendered when searchComplete prop changes. This is why it was a race condition