### PR TITLE
Fix issues with tiles being lost

### DIFF
--- a/src/actions/search-results.js
+++ b/src/actions/search-results.js
@@ -20,7 +20,6 @@ import {
 import * as graphqlService from '../services/graphql';
 import { formatQuery } from './helpers.js';
 // routing actionCreator
-import shuffle from 'shuffle-array';
 import timers from 'timers';
 /*
 * saves the error to the store to display an error message
@@ -156,17 +155,16 @@ export function mixDataInput () {
 
   function shake () {
     const total = tiles.length + packages.length;
-    // randomise tiles
-    shuffle(tiles);
-    // sort by rank packages
 
     // weave tiles and packages to mixture
     for (let i = 1; i < total + 1; i++) {
       if (packages.length > 0) {
-        if (i % 6) {
-          tiles.length ? mixture.push(tiles.pop()) : false;
+        if (i % 6 && tiles.length) {
+          mixture.push(tiles.pop());
         }
         mixture.push(packages.pop());
+      } else if (tiles.length > 0) {
+        mixture.push(tiles.pop());
       }
     }
   }


### PR DESCRIPTION
Because tiles is reset to be a filter of the mixture at https://github.com/numo-labs/isearch-ui/blob/master/src/actions/search-results.js#L187 any tiles which are not pushed onto the mixture are lost at the next iteration of the mixing function. This means that if there are more tiles than 1/6th of the number of packages then they are never rendered.

By ensuring that all tiles are always pushed onto the end of the mixture if they are not interspersed then we can prevent them from being lost.

Additionally remove the shuffle function, since we should now receive tiles in (roughly) ranking order.