### PR TITLE
Prevent isearch component triggering search on mount

### DIFF
--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -25,9 +25,6 @@ class ISearch extends Component {
   componentWillMount () {
     window.addEventListener('resize', this.handleResize);
     this.addAnalyticsData();
-    if (!this.props.tags.length) {
-      this.props.resetTags();
-    }
   }
 
   handleResize () {

--- a/test/components/isearch.test.js
+++ b/test/components/isearch.test.js
@@ -66,19 +66,5 @@ describe('Component', function () {
       expect(error).to.have.length(1);
       done();
     });
-    it('should call reset tags if there is no tags at store while rendering', function (done) {
-      const stub = sinon.stub();
-      const props = {...defaultProps, resetTags: stub};
-      shallow(<ISearch {...props} />);
-      expect(stub.callCount).to.equal(1);
-      done();
-    });
-    it('should not call reset tags if there is tags ', function (done) {
-      const stub = sinon.stub();
-      const props = {...defaultProps, tags: ['testing tag'], resetTags: stub};
-      shallow(<ISearch {...props} />);
-      expect(stub.callCount).to.equal(0);
-      done();
-    });
   });
 });


### PR DESCRIPTION
Resetting the tags to default is already performed once the websocket connection is established and the ui is ready to receive results. Performing an additional reset here is redundant because the connection id is not yet present, and so cannot be used to pipe any results from the resultant search back to the user.