### PR TITLE
Teardown interval on component unmount

### DIFF
--- a/lib/search-bar/index.js
+++ b/lib/search-bar/index.js
@@ -159,7 +159,10 @@ export default class SearchBarContainer extends Component {
     }
   }
   componentDidMount () {
-    setInterval(this.placeholderSwitch.bind(this), 4000);
+    this.interval = setInterval(this.placeholderSwitch.bind(this), 4000);
+  }
+  componentWillUnmount () {
+    clearInterval(this.interval);
   }
 
   render () {


### PR DESCRIPTION
If the interval is not torn down then it causes multiple js errors about setting state on an unmounted component to be rendered to the console if opening an article and then returning to search.