### PR TITLE
Autocomplete

### DIFF
--- a/lib/search-bar/index.js
+++ b/lib/search-bar/index.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import Autosuggest from 'react-autosuggest';
 import { noSuggestions, defaultSuggestions } from './defaultSuggestions';
+import LoadingSpinner from '../spinner';
 import './style.css';
 let counter = 0;
 const searchIcon = require('../../src/assets/search.svg');
@@ -150,7 +151,7 @@ export default class SearchBarContainer extends Component {
 
   render () {
     const { value, suggestions, multiSection, placeholder } = this.state;
-    const { departureDate, showTravelInfo } = this.props;
+    const { departureDate, showTravelInfo, inAutoCompleteSearch } = this.props;
     const inputProps = {
       placeholder: placeholder,
       value,
@@ -163,6 +164,7 @@ export default class SearchBarContainer extends Component {
       <div className='searchBarContainer'>
         <div className='inputContainer'>
           <img src={searchIcon} className='searchIcon' alt='search'/>
+          {inAutoCompleteSearch && <div className='autosuggestSpinner'><LoadingSpinner /></div>}
           <Autosuggest
             suggestions={suggestions}
             onSuggestionsUpdateRequested={this.onSuggestionsUpdateRequested}
@@ -199,6 +201,7 @@ SearchBarContainer.propTypes = {
   // autocomplete
   autocompleteOptions: PropTypes.array,
   getAutocompleteOptions: PropTypes.func,
+  inAutoCompleteSearch: PropTypes.bool,
 
   // navigation
   go: PropTypes.func,

--- a/lib/search-bar/index.js
+++ b/lib/search-bar/index.js
@@ -175,6 +175,7 @@ export default class SearchBarContainer extends Component {
             renderSectionTitle={renderSectionTile}
             getSectionSuggestions={getSectionSuggestions}
             shouldRenderSuggestions={() => true}
+            focusFirstSuggestion
           />
           <div className='travelInfoChange' onClick={() => showTravelInfo()}>
             <div className='leavingDate'>{`Tidigste afrejse: ` + departureDate}</div>

--- a/lib/search-bar/style.css
+++ b/lib/search-bar/style.css
@@ -54,11 +54,18 @@
   outline: 0;
 }
 
+.autosuggestSpinner,
 .searchIcon {
   width: 1.3em;
   position: absolute;
   top: 1em;
+}
+.searchIcon {
   left: 0.7em;
+}
+.autosuggestSpinner {
+  right: 1.3em;
+  top: 0.1em;
 }
 
 .react-autosuggest__section-container {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "node-zopfli": "^1.4.0",
     "pre-commit": "^1.1.3",
     "react-addons-test-utils": "^0.14.8",
-    "react-autosuggest": "^3.7.4",
     "react-dom": "^0.14.8",
     "react-hot-loader": "^1.3.0",
     "redux-logger": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "moment": "^2.12.0",
     "querystring": "^0.2.0",
     "react": "^0.14.7",
+    "react-autosuggest": "^3.9.0",
     "react-dom": "^0.14.7",
     "react-google-maps": "^4.11.0",
     "react-masonry-component": "^4.0.0",


### PR DESCRIPTION
[Ready for review]

Closes #489


### Expected Behaviour
The dropdown should remain open when focus is set to the input field


Current status: 

### Actual Behaviour
- [x] Pressing enter when focus is set to the input field will close the dropdown.
In this video I click enter after I have typed London.
[link](https://drive.google.com/open?id=0BwJ2qQvXEjayUENKNzNLR1hzYUU)

- [x] Removing all text fast with backspace closes the dropdown.
[link](https://drive.google.com/open?id=0BwJ2qQvXEjaybkFoWS1NVnB2TjA)

- [x] Sometimes the dropdown disappears when typing.
[link](https://drive.google.com/open?id=0BwJ2qQvXEjayak1UQkJDaGV1Tkk)


This last 2 checkpoints were due to the lack of a rerender action because we were not tracking state of the autocomplete search itself. Now I've added a spinner: 
![image](https://cloud.githubusercontent.com/assets/8338963/17242861/d38fb134-5579-11e6-960d-89c863d7ec82.png)
On that way, we have a variable to track the state, so the autocomplete options will be rendered when needed. Also, the spinner will be displayed to show to the user that the app is doing something.
