### PR TITLE
Tweak timing of loading search results to improve sorting

### DIFF
--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -49,9 +49,10 @@ export const initialState = {
   departureAirport: '',
   departureDate: '',
   passengerBirthdays: [],
-  initialPageSize: 10,
+  initialPageSize: 2, // the number of search results to show *immediately*
+  secondaryPageSize: 20, // show this many results after 3 seconds or when there is a gap in incoming results
   pageSize: 5,
-  searchComplete: false, // set to false until a message is recieved from the web socket channel
+  searchComplete: false, // set to false until a message is received from the web socket channel
   feedEnd: false,
   ranking: {}
 };

--- a/test/actions/search-results.test.js
+++ b/test/actions/search-results.test.js
@@ -153,14 +153,14 @@ describe('Search Results Actions', () => {
   });
   describe('Inifinite Scroll actions', () => {
     it(`loadMoreItemsIntoFeed: dispatch updateDisplayedItems action with
-      items if current 'displayedItems' state is less than initialPageSize and
+      items if current 'displayedItems' state is less than secondaryPageSize and
       'items' state has items`, done => {
       const items = [
         {id: 'one', rank: 3},
         {id: 'two', rank: 2},
         {id: 'three', rank: 1}
       ];
-      const store = mockStore({search: { displayedItems: [], items, pageSize: 5, initialPageSize: 10 }});
+      const store = mockStore({search: { displayedItems: [], items, pageSize: 5, secondaryPageSize: 10 }});
       const expectedActions = [{type: UPDATE_DISPLAYED_ITEMS, items}];
       store.dispatch(actions.loadMoreItemsIntoFeed());
       expect(store.getActions()).to.deep.equal(expectedActions);
@@ -181,13 +181,13 @@ describe('Search Results Actions', () => {
         {id: 9},
         {id: 10}
       ];
-      const store = mockStore({search: { displayedItems: items.slice(0, 2), items, pageSize: 5, initialPageSize: 0 }});
+      const store = mockStore({search: { displayedItems: items.slice(0, 2), items, pageSize: 5, secondaryPageSize: 0 }});
       const expectedAction = {type: UPDATE_DISPLAYED_ITEMS, items: items.slice(0, 7)};
       store.dispatch(actions.loadMoreItemsIntoFeed());
       expect(store.getActions()[0]).to.deep.equal(expectedAction);
       done();
     });
-    it(`loadMoreItemsIntoFeed: if the length of items is less than the initialPageSize
+    it(`loadMoreItemsIntoFeed: if the length of items is less than the secondaryPageSize
       dispatch updateDisplayedItems with all the available items`, done => {
       const items = [
         {id: 1},
@@ -198,7 +198,7 @@ describe('Search Results Actions', () => {
         {id: 6},
         {id: 7}
       ];
-      const store = mockStore({search: { displayedItems: [], items, initialPageSize: 10, pageSize: 5 }});
+      const store = mockStore({search: { displayedItems: [], items, secondaryPageSize: 10, pageSize: 5 }});
       const expectedActions = [{type: UPDATE_DISPLAYED_ITEMS, items}];
       store.dispatch(actions.loadMoreItemsIntoFeed());
       expect(store.getActions()).to.deep.equal(expectedActions);


### PR DESCRIPTION
Show the first two results to be received immediately to give user feedback about the search success. Then either after 3 seconds, or a gap in result loading display the first 20.

This allows more of the early results to be buffered into the stream and therefore to be sorted using our ranking algorithm, while still giving the user fast feedback.