### PR TITLE
Use full result set for determining display of "no hotels" warning

### DIFF
--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -62,7 +62,8 @@ class ISearch extends Component {
       feedEnd,
       showTravelInfo,
       tags,
-      isInitialTag
+      isInitialTag,
+      ranking
     } = this.props;
     return (
       <ScrollView
@@ -86,6 +87,7 @@ class ISearch extends Component {
           showTravelInfo={showTravelInfo}
           tags={tags}
           isInitialTag={isInitialTag}
+          ranking={ranking}
         />
       </ScrollView>
     );
@@ -235,6 +237,7 @@ ISearch.propTypes = {
   displayedItems: PropTypes.array,
   onYesFilter: PropTypes.func,
   onFilterClick: PropTypes.func,
+  ranking: PropTypes.object,
 
   // scroll view
   loadMoreItemsIntoFeed: PropTypes.func,

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -222,10 +222,11 @@ class SearchResults extends Component {
       searchComplete,
       items,
       showTravelInfo,
-      isInitialTag
+      isInitialTag,
+      ranking
     } = this.props;
     const searchItems = items.filter(item => !item.related);
-    const hotelItems = searchItems.filter(item => item.packageOffer);
+    const hotelItems = ranking ? Object.keys(ranking).filter(key => key.match(/^hotel/)) : [];
     const hideGridStyle = {
       minHeight: '0'
     };
@@ -272,7 +273,8 @@ SearchResults.propTypes = {
   searchComplete: PropTypes.bool,
   feedEnd: PropTypes.bool,
   showTravelInfo: PropTypes.func,
-  isInitialTag: PropTypes.bool
+  isInitialTag: PropTypes.bool,
+  ranking: PropTypes.object
 };
 
 export default SearchResults;

--- a/src/containers/isearch.js
+++ b/src/containers/isearch.js
@@ -32,7 +32,8 @@ function mapStateToProps (state) {
       resultId,
       searchComplete,
       feedEnd,
-      isInitialTag
+      isInitialTag,
+      ranking
     },
     travelInfo: {
       numberOfChildren,
@@ -94,7 +95,8 @@ function mapStateToProps (state) {
     searchComplete,
     feedEnd,
     editDetailsVisible,
-    isInitialTag
+    isInitialTag,
+    ranking
   };
 }
 

--- a/test/components/search-results.test.js
+++ b/test/components/search-results.test.js
@@ -122,5 +122,22 @@ describe('Component', function () {
       expect(wrapper2.find('.visited').length).to.equal(1);
       done();
     });
+    it('should show a warning message when search is complete if results contain no hotels', () => {
+      const ranking = {
+        'article:1': 1,
+        'article:2': 2
+      };
+      const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} searchComplete ranking={ranking}/>);
+      expect(wrapper.find('.noHotelsErrorMessage').length).to.equal(1);
+    });
+    it('should not show a warning message when search is complete if results contains hotels', () => {
+      const ranking = {
+        'article:1': 1,
+        'article:2': 2,
+        'hotel:1': 3
+      };
+      const wrapper = shallow(<SearchResults changeRoute={() => {}} items={mockTiles.items} viewedArticles={[]} searchComplete ranking={ranking}/>);
+      expect(wrapper.find('.noHotelsErrorMessage').length).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
At the moment only the *displayed* results are used to determine the display of the "no hotels" message which means a lot of the time it is displayed when it shouldn't be, as at the time when the "search complete" event fires, there are often only a very small subset of the results rendered.

By using the ranking data, which is available early on, we can inspect the entire result set, and show the message only when it truly applies.