### PR TITLE
[ready] empty string not tracked as input text

### DIFF
--- a/lib/search-bar/index.js
+++ b/lib/search-bar/index.js
@@ -118,14 +118,16 @@ export default class SearchBarContainer extends Component {
         multiSection: multiSection
       });
       clearTimeout(keyPressTimeout);
-      keyPressTimeout = setTimeout(() => {
-        const analyticsObject = {
-          event: 'searchTyping',
-          searchInput: value,
-          suggestions: this.props.autocompleteOptions ? this.props.autocompleteOptions.length : 0
-        };
-        dataLayer.push(analyticsObject);
-      }, 3000);
+      if (value && this.state.value === value && value !== '') {
+        keyPressTimeout = setTimeout(() => {
+          const analyticsObject = {
+            event: 'searchTyping',
+            searchInput: value,
+            suggestions: this.props.autocompleteOptions ? this.props.autocompleteOptions.length : 0
+          };
+          dataLayer.push(analyticsObject);
+        }, 3000);
+      }
     });
   }
   placeholderSwitch () {
@@ -194,6 +196,7 @@ export default class SearchBarContainer extends Component {
               renderSectionTitle={renderSectionTile}
               getSectionSuggestions={getSectionSuggestions}
               shouldRenderSuggestions={() => true}
+              focusFirstSuggestion
             />
           </div>
           <div className='travelInfoChange' onClick={() => showTravelInfo()}>


### PR DESCRIPTION
**Ready for review**

Improved the way we track input text, now when deleting all the content we do not track the empty string. The event only triggers if the value is the current one (it may change fast between typing and receiving suggestions from back-end).

 Note: added `focusFirstSuggestions` to autosuggest element because it seems to have been lost in a recent merge. 