### PR TITLE
fix item related

### DIFF
--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -15,7 +15,7 @@ const impressionObject = {
       'dimension11': item.packageOffer.destinationCode,
       'dimension12': item.packageOffer.destinationName,
       'dimension13': item.packageOffer.departureCode,
-      'tiles_displayed': item.related ? 'auto displayed' : 'search or filter results'
+      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
     };
   },
   filter: (item) => {
@@ -23,7 +23,7 @@ const impressionObject = {
       'id': item.id,
       'brand': 'filter_tile',
       'list': 'inspirational search feed',
-      'tiles_displayed': item.related ? 'auto displayed' : 'search or filter results'
+      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
     };
   },
   tile: (item) => {
@@ -32,12 +32,12 @@ const impressionObject = {
       'category': 'article category', // can this be fetched?
       'brand': 'article_tile', // hardcoded
       'list': 'inspirational search feed',
-      'tiles_displayed': item.related ? 'auto displayed' : 'search or filter results'
+      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
     } : {
       'id': item.tile.name,
       'brand': 'destination_tile', // hardcoded
       'list': 'inspirational search feed',
-      'tiles_displayed': item.related ? 'auto displayed' : 'search or filter results'
+      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
     };
   }
 };

--- a/lib/analytics-helper/index.js
+++ b/lib/analytics-helper/index.js
@@ -14,16 +14,14 @@ const impressionObject = {
       'list': 'inspirational search feed',
       'dimension11': item.packageOffer.destinationCode,
       'dimension12': item.packageOffer.destinationName,
-      'dimension13': item.packageOffer.departureCode,
-      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
+      'dimension13': item.packageOffer.departureCode
     };
   },
   filter: (item) => {
     return {
       'id': item.id,
       'brand': 'filter_tile',
-      'list': 'inspirational search feed',
-      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
+      'list': 'inspirational search feed'
     };
   },
   tile: (item) => {
@@ -31,13 +29,11 @@ const impressionObject = {
       'id': item.tile.name,
       'category': 'article category', // can this be fetched?
       'brand': 'article_tile', // hardcoded
-      'list': 'inspirational search feed',
-      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
+      'list': 'inspirational search feed'
     } : {
       'id': item.tile.name,
       'brand': 'destination_tile', // hardcoded
-      'list': 'inspirational search feed',
-      'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results'
+      'list': 'inspirational search feed'
     };
   }
 };
@@ -50,6 +46,7 @@ const impressionObject = {
 export const impresionDataFactory = (item) => {
   var analyticsImpression = {
     'event': 'impressionsPushed',
+    'tiles_displayed': item.autoDisplayed ? 'auto displayed' : 'search or filter results',
     'ecommerce': {
       'impressions': [ impressionObject[ item.type ](item) ]
     }

--- a/lib/analytics-helper/test/analytics-fixtures.js
+++ b/lib/analytics-helper/test/analytics-fixtures.js
@@ -12,13 +12,13 @@ export default {
     },
     expectedResult: {
       'event': 'impressionsPushed',
+      'tiles_displayed': 'search or filter results',
       'ecommerce': {
         'impressions': [{
           'id': 'articleName',
           'category': 'article category',
           'brand': 'article_tile',
-          'list': 'inspirational search feed',
-          'tiles_displayed': 'search or filter results'
+          'list': 'inspirational search feed'
         }]
       }
     }
@@ -37,6 +37,7 @@ export default {
     },
     expectedResult: {
       'event': 'impressionsPushed',
+      'tiles_displayed': 'search or filter results',
       'ecommerce': {
         'impressions': [{
           'id': 'fixtureReference',
@@ -44,8 +45,7 @@ export default {
           'list': 'inspirational search feed',
           'dimension11': 'destCode',
           'dimension12': 'destName',
-          'dimension13': 'depCode',
-          'tiles_displayed': 'search or filter results'
+          'dimension13': 'depCode'
         }]
       }
     }
@@ -57,12 +57,12 @@ export default {
     },
     expectedResult: {
       'event': 'impressionsPushed',
+      'tiles_displayed': 'search or filter results',
       'ecommerce': {
         'impressions': [{
           'id': 'filterID',
           'brand': 'filter_tile',
-          'list': 'inspirational search feed',
-          'tiles_displayed': 'search or filter results'
+          'list': 'inspirational search feed'
         }]
       }
     }
@@ -78,12 +78,12 @@ export default {
     },
     expectedResult: {
       'event': 'impressionsPushed',
+      'tiles_displayed': 'search or filter results',
       'ecommerce': {
         'impressions': [{
           'id': 'destinationName',
           'brand': 'destination_tile',
-          'list': 'inspirational search feed',
-          'tiles_displayed': 'search or filter results'
+          'list': 'inspirational search feed'
         }]
       }
     }

--- a/src/components/search-results/index.js
+++ b/src/components/search-results/index.js
@@ -90,7 +90,7 @@ class SearchResults extends Component {
         if (item.message) {
           return item.message;
         } else {
-          item.related = item.related || this.props.isInitialTag;
+          item.autoDisplayed = item.related || this.props.isInitialTag;
           return (
             <VisibilitySensor key={start + index} onChange={(isVisible) => this.handleVisibility(isVisible, item)}>
               <div key={index} className='gridItem'>


### PR DESCRIPTION
With this: https://github.com/numo-labs/isearch-ui/pull/503, setting the related variable when it shoudn't be there, I broke the homepage visualization. 

Changing the variable to `autoDisplayed` it's clear that has a totally different objetive. 
