### PR TITLE
Prevent ranking data for related search being saved

### DIFF
--- a/src/actions/search-results.js
+++ b/src/actions/search-results.js
@@ -210,7 +210,7 @@ export function updateTileRanking (result) {
   return (dispatch, getState) => {
     const { search: { resultId } } = getState();
     const searchId = result.graphql.searchId;
-    if (resultId && searchId.indexOf(resultId) > -1) { // check data corresponds to the current search
+    if (resultId && searchId.indexOf(resultId) > -1 && searchId.indexOf('related') === -1) { // check data corresponds to the current search
       dispatch({ type: UPDATE_TILE_RANKING, ranking: result.graphql.ranking });
     }
   };


### PR DESCRIPTION
On some occasions the ranking data for the related results was being used in place of the proper data, which results in the "no hotels" message being displayed, since the related results never contain hotels.