### PR TITLE
Query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "react-visibility-sensor": "^3.0.0",
     "redux": "^3.5.2",
     "shuffle-array": "^1.0.0",
-    "spies-url-parser": "^1.0.5",
     "striptags": "^2.1.1",
     "uuid": "^2.0.2",
     "whatwg-fetch": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "react-visibility-sensor": "^3.0.0",
     "redux": "^3.5.2",
     "shuffle-array": "^1.0.0",
+    "spies-url-parser": "^1.0.5",
     "striptags": "^2.1.1",
     "uuid": "^2.0.2",
     "whatwg-fetch": "^1.0.0"

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -51,7 +51,11 @@ class ISearch extends Component {
     });
     if (parsedQuery.travelAdults > 0) setNumberOfAdults(parsedQuery.travelAdults);
     if (parsedQuery.travelChildren > 0) setNumberOfChildren(parsedQuery.travelChildren);
-    if (parsedQuery.travelDuration > 0) setDuration(parsedQuery.travelDuration + ' uge' + (parsedQuery.travelDuration > 1 ? 'r' : ''));
+    if (!isNaN(parsedQuery.travelDuration) && parsedQuery.travelDuration > 0) {
+      // We get duration as number of days, but we are using weeks so we need to convert it.
+      let durationWeeks = Math.round(parsedQuery.travelDuration / 7);
+      setDuration(durationWeeks + ' uge' + (durationWeeks > 1 ? 'r' : ''));
+    }
     if (parsedQuery.travelDepartureCode) setDepartureAirport(departureOptions[parsedQuery.travelDepartureCode]);
     updateHeaderTitles();
   }

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -20,11 +20,40 @@ class ISearch extends Component {
       endScroll: false
     };
     this.handleResize = this.handleResize.bind(this);
+    this.loadQueryParams = this.loadQueryParams.bind(this);
   }
 
   componentWillMount () {
     window.addEventListener('resize', this.handleResize);
     this.addAnalyticsData();
+    let params = document.location.search.replace('?', '').split('&');
+    this.loadQueryParams(params);
+  }
+  loadQueryParams (params) {
+    if (!params.length) return;
+    const departureOptions = {
+      BLL: 'Billund - BLL',
+      CPH: 'København - CPH',
+      ALL: 'Aalborg - AAL',
+      ODE: 'Odense - ODE',
+      RNN: 'Rønne - RNN'
+    };
+    const {
+      setNumberOfChildren,
+      setNumberOfAdults,
+      setDepartureAirport,
+      setDuration,
+      updateHeaderTitles
+    } = this.props;
+    let parsedQuery = {};
+    params.map((param) => {
+      parsedQuery[param.split('=')[0]] = param.split('=')[1] || true;
+    });
+    if (parsedQuery.travelAdults > 0) setNumberOfAdults(parsedQuery.travelAdults);
+    if (parsedQuery.travelChildren > 0) setNumberOfChildren(parsedQuery.travelChildren);
+    if (parsedQuery.travelDuration > 0) setDuration(parsedQuery.travelDuration + ' uge' + (parsedQuery.travelDuration > 1 ? 'r' : ''));
+    if (parsedQuery.travelDepartureCode) setDepartureAirport(departureOptions[parsedQuery.travelDepartureCode]);
+    updateHeaderTitles();
   }
 
   handleResize () {

--- a/src/components/isearch/index.js
+++ b/src/components/isearch/index.js
@@ -7,6 +7,7 @@ import LoadingSpinner from '../../../lib/spinner';
 import ScrollView from '../../../lib/scroll-view';
 import EditDetails from '../edit-details';
 import departOnFriday from '../../utils/departure-day-format';
+import departureOptions from '../../constants/departureOptions';
 import moment from 'moment';
 import './style.css';
 
@@ -26,18 +27,11 @@ class ISearch extends Component {
   componentWillMount () {
     window.addEventListener('resize', this.handleResize);
     this.addAnalyticsData();
-    let params = document.location.search.replace('?', '').split('&');
-    this.loadQueryParams(params);
+    this.loadQueryParams(document.location.search);
   }
-  loadQueryParams (params) {
+  loadQueryParams (query) {
+    let params = query.replace('?', '').split('&');
     if (!params.length) return;
-    const departureOptions = {
-      BLL: 'Billund - BLL',
-      CPH: 'København - CPH',
-      ALL: 'Aalborg - AAL',
-      ODE: 'Odense - ODE',
-      RNN: 'Rønne - RNN'
-    };
     const {
       setNumberOfChildren,
       setNumberOfAdults,
@@ -49,14 +43,14 @@ class ISearch extends Component {
     params.map((param) => {
       parsedQuery[param.split('=')[0]] = param.split('=')[1] || true;
     });
-    if (parsedQuery.travelAdults > 0) setNumberOfAdults(parsedQuery.travelAdults);
-    if (parsedQuery.travelChildren > 0) setNumberOfChildren(parsedQuery.travelChildren);
+    if (!isNaN(parsedQuery.travelAdults) && parsedQuery.travelAdults > 0) setNumberOfAdults(parsedQuery.travelAdults);
+    if (!isNaN(parsedQuery.travelChildren) && parsedQuery.travelChildren > 0) setNumberOfChildren(parsedQuery.travelChildren);
     if (!isNaN(parsedQuery.travelDuration) && parsedQuery.travelDuration > 0) {
       // We get duration as number of days, but we are using weeks so we need to convert it.
       let durationWeeks = Math.round(parsedQuery.travelDuration / 7);
       setDuration(durationWeeks + ' uge' + (durationWeeks > 1 ? 'r' : ''));
     }
-    if (parsedQuery.travelDepartureCode) setDepartureAirport(departureOptions[parsedQuery.travelDepartureCode]);
+    if (parsedQuery.travelDepartureCode && departureOptions[parsedQuery.travelDepartureCode]) setDepartureAirport(departureOptions[parsedQuery.travelDepartureCode]);
     updateHeaderTitles();
   }
 

--- a/src/constants/departureOptions.js
+++ b/src/constants/departureOptions.js
@@ -1,0 +1,7 @@
+export default {
+  BLL: 'Billund - BLL',
+  CPH: 'København - CPH',
+  ALL: 'Aalborg - AAL',
+  ODE: 'Odense - ODE',
+  RNN: 'Rønne - RNN'
+};

--- a/test/components/isearch.test.js
+++ b/test/components/isearch.test.js
@@ -17,7 +17,8 @@ const defaultProps = {
   removeTag: () => {},
   addSingleTag: () => {},
   addTag: () => {},
-  resetTags: () => {}
+  resetTags: () => {},
+  updateHeaderTitles: () => {}
 };
 
 describe('Component', function () {

--- a/test/components/isearch.test.js
+++ b/test/components/isearch.test.js
@@ -67,5 +67,37 @@ describe('Component', function () {
       expect(error).to.have.length(1);
       done();
     });
+    it('should update travel preferences if provided', (done) => {
+      const query = '?travelAdults=3&travelChildren=1&travelDuration=8&travelDepartureCode=ODE';
+      const spies = {
+        setNumberOfAdults: sinon.spy(),
+        setNumberOfChildren: sinon.spy(),
+        setDuration: sinon.spy(),
+        setDepartureAirport: sinon.spy()
+      };
+      wrapper.setProps(spies);
+      wrapper.instance().loadQueryParams(query);
+      expect(spies.setNumberOfAdults.calledWith('3')).to.be.true;
+      expect(spies.setNumberOfChildren.calledWith('1')).to.be.true;
+      expect(spies.setDuration.calledWith('1 uge')).to.be.true;
+      expect(spies.setDepartureAirport.calledWith('Odense - ODE')).to.be.true;
+      done();
+    });
+    it('should not update travel preferences if provided is not valid', (done) => {
+      const query = '?travelAdults=three&travelChildren=one&travelDuration=eight&travelDepartureCode=invalidCode';
+      const spies = {
+        setNumberOfAdults: sinon.spy(),
+        setNumberOfChildren: sinon.spy(),
+        setDuration: sinon.spy(),
+        setDepartureAirport: sinon.spy()
+      };
+      wrapper.setProps(spies);
+      wrapper.instance().loadQueryParams(query);
+      expect(spies.setNumberOfAdults.called).to.be.false;
+      expect(spies.setNumberOfChildren.called).to.be.false;
+      expect(spies.setDuration.called).to.be.false;
+      expect(spies.setDepartureAirport.called).to.be.false;
+      done();
+    });
   });
 });


### PR DESCRIPTION
Url query params used as default search values. 

See https://github.com/numo-labs/release/issues/21

Mapping directly from https://github.com/numo-labs/isearch-ui/blob/master/src/components/edit-details/options.js

So, the only valid to display values for `travelDuration` would be 1, 2, 3 or 4. (So as to be able to display it correctly in the popup).
With travel departure code a mapping is done. So valid values are: `CPH`, `BLL`, `AAL`, `ODE` and `RNN`.