### PR TITLE
Correctly map hotel ids to full ids

### DIFF
--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -61,15 +61,15 @@ export default function search (state = initialState, action) {
   switch (action.type) {
     case RECEIVE_SEARCH_RESULT:
       const itemsToDisplay = uniqBy(union(state.items, action.items), (a) => {
-        if (a.packageOffer) {
-          return a.packageOffer.provider.reference;
-        } else {
-          return a.id;
-        }
+        return a.id;
       });
       itemsToDisplay.forEach((item) => {
         if (state.ranking) {
-          item.rank = parseFloat(state.ranking[item.id]) || 0;
+          let id = item.id;
+          if (item.type === 'package') {
+            id = `hotel:ne.wvid.${item.id}`;
+          }
+          item.rank = parseFloat(state.ranking[id]) || 0;
         }
       });
       return {
@@ -111,7 +111,11 @@ export default function search (state = initialState, action) {
       };
     case UPDATE_TILE_RANKING:
       state.items.forEach(item => {
-        item.rank = parseFloat(action.ranking[item.id]) || 0;
+        let id = item.id;
+        if (item.type === 'package') {
+          id = `hotel:ne.wvid.${item.id}`;
+        }
+        item.rank = parseFloat(action.ranking[id]) || 0;
       });
       return {
         ...state,

--- a/test/reducers/search.test.js
+++ b/test/reducers/search.test.js
@@ -61,18 +61,37 @@ describe('Search Reducer', () => {
     it(`RECEIVE_SEARCH_RESULT-> includes ranking data on saved results`, (done) => {
       const initialStateWithItems = {
         ...initialState,
-        items: mockItems,
+        items: [],
         ranking: {
-          e73e4919e237887f70f6024011502243: '7'
+          'tile:marketing.1234': '7'
         }
       };
       const action = {
         type: RECEIVE_SEARCH_RESULT,
-        items: mockItems
+        items: [ { id: 'tile:marketing.1234', type: 'tile' } ]
       };
       const state = reducer(initialStateWithItems, action);
       expect(state.loading).to.be.false;
-      expect(state.items[0].id).to.equal('e73e4919e237887f70f6024011502243');
+      expect(state.items[0].id).to.equal('tile:marketing.1234');
+      expect(state.items[0].rank).to.equal(7);
+      done();
+    });
+    it(`RECEIVE_SEARCH_RESULT-> maps package hotel ids to full ids`, (done) => {
+      const initialStateWithItems = {
+        ...initialState,
+        items: [],
+        ranking: {
+          'hotel:ne.wvid.1234': '7'
+        }
+      };
+      const action = {
+        type: RECEIVE_SEARCH_RESULT,
+        items: [
+          { id: '1234', type: 'package' }
+        ]
+      };
+      const state = reducer(initialStateWithItems, action);
+      expect(state.items[0].id).to.equal('1234');
       expect(state.items[0].rank).to.equal(7);
       done();
     });


### PR DESCRIPTION
The ids of the returned ranking map are full ids, so we need to prefix the numerical id in order to do the lookup correctly.