### PR TITLE
Disable Map Scroll Mobile

### DIFF
--- a/src/components/destination/index.js
+++ b/src/components/destination/index.js
@@ -15,12 +15,17 @@ class DestinationFullPage extends Component {
     } = this.props;
     const latitude = articleContent.location ? Number(articleContent.location.lat) : 0;
     const longitude = articleContent.location ? Number(articleContent.location.lon) : 0;
+    const isDraggable = window.innerWidth > 750;
     const marker = {
       position: {
         lat: latitude,
         lng: longitude
       },
       defaultAnimation: 4
+    };
+    const mapOptions = {
+      scrollwheel: false,
+      draggable: isDraggable
     };
     return (
       <ArticleFullPage
@@ -41,7 +46,7 @@ class DestinationFullPage extends Component {
                 ref={(map) => (map) => console.log(map)}
                 defaultZoom={6}
                 defaultCenter={marker.position}
-                options={{scrollwheel: false}}
+                options={mapOptions}
               >
               <Marker
                 {...marker}

--- a/src/components/destination/index.js
+++ b/src/components/destination/index.js
@@ -3,6 +3,11 @@ import { GoogleMapLoader, GoogleMap, Marker } from 'react-google-maps';
 import ArticleFullPage from '../article';
 
 class DestinationFullPage extends Component {
+  isTouchDevice () {
+    return (('ontouchstart' in window) ||
+      (navigator.MaxTouchPoints > 0) ||
+      (navigator.msMaxTouchPoints > 0));
+  }
   render () {
     const {
       articleContent,
@@ -15,7 +20,6 @@ class DestinationFullPage extends Component {
     } = this.props;
     const latitude = articleContent.location ? Number(articleContent.location.lat) : 0;
     const longitude = articleContent.location ? Number(articleContent.location.lon) : 0;
-    const isDraggable = window.innerWidth > 750;
     const marker = {
       position: {
         lat: latitude,
@@ -25,7 +29,7 @@ class DestinationFullPage extends Component {
     };
     const mapOptions = {
       scrollwheel: false,
-      draggable: isDraggable
+      draggable: !this.isTouchDevice()
     };
     return (
       <ArticleFullPage


### PR DESCRIPTION
## ready for review
- removes the draggable property from mobile maps  
  #530

We need to find a way to test the map options of the google map so that we can see if the zoom changes once a user has scrolled onto the map

[link to issue](https://github.com/numo-labs/isearch-ui/issues/548)
